### PR TITLE
Add engine-specific effect size calculations

### DIFF
--- a/R/effects.R
+++ b/R/effects.R
@@ -1,26 +1,38 @@
 #' Add an effect size to a fitted comparison
 #'
-#' Compute Hedges' *g* (with a confidence interval) for a two‑group,
-#' numeric outcome and store it on the `comp_spec`. This is a
-#' post‑fit step that reads from `spec$fitted` and writes the following:
-#' `es_value`, `es_conf_low`, `es_conf_high`, and `es_metric` (set to
-#' `"Hedges_g"`).
+#' Compute an effect size (with a confidence interval) for a two‑group,
+#' numeric outcome based on the inferential engine stored in
+#' `spec$fitted$engine`. Supported tests map to the following metrics:
+#'
+#' - `"student_t"`: Cohen's *d* (no Hedges correction)
+#' - `"welch_t"`: Hedges' *g* (default) or Cohen's *d* when
+#'   `effect = "cohens_d"`
+#' - `"mann_whitney"`: Wilcoxon *r* (rank biserial)
+#'
+#' The function reads from `spec$fitted` and writes `es_value`,
+#' `es_conf_low`, `es_conf_high`, and `es_metric` before returning `spec`.
 #'
 #' @param spec A `comp_spec` created by [comp_spec()] and already fitted
 #'   via `test()` (i.e., `spec$fitted` must exist). Roles must include a
 #'   numeric outcome and a two‑level group.
 #' @param conf_level Confidence level for the interval (numeric in (0, 1),
 #'   default `0.95`).
+#' @param effect Optional override for some engines. Currently, only
+#'   `effect = "cohens_d"` is supported for the `welch_t` engine to
+#'   compute Cohen's *d* instead of Hedges' *g*.
 #'
 #' @details
 #' - Supported design: two‑group comparison with a **numeric** outcome.
-#' - Backend: [`effectsize::hedges_g()`](https://easystats.github.io/effectsize/).
+#' - Backend functions from the
+#'   [`effectsize`](https://easystats.github.io/effectsize/) package
+#'   (e.g., `hedges_g()`, `cohens_d()`, `rank_biserial()`).
 #' - If the **effectsize** package is not installed, a warning is issued
 #'   and the input `spec` is returned unchanged.
 #'
 #' The function selects `spec$data_prepared` when available, otherwise
 #' falls back to `spec$data_raw`. It standardizes inputs internally and
-#' then calls `effectsize::hedges_g(outcome ~ group, ...)`.
+#' then calls the appropriate effect size function based on
+#' `spec$fitted$engine`.
 #'
 #' @return The input `spec`, updated in place with effect‑size fields in
 #'   `spec$fitted`: `es_value`, `es_conf_low`, `es_conf_high`, `es_metric`.
@@ -45,7 +57,7 @@
 #' # spec$fitted$es_metric
 #'
 #' @export
-effects <- function(spec, conf_level = 0.95) {
+effects <- function(spec, conf_level = 0.95, effect = "default") {
   stopifnot(inherits(spec, "comp_spec"))
   if (is.null(spec$fitted)) {
     cli::cli_abort("Run `test()` before `effects()`.")
@@ -61,13 +73,70 @@ effects <- function(spec, conf_level = 0.95) {
     spec$roles$outcome,
     spec$roles$group
   )
-  es <- effectsize::hedges_g(outcome ~ group, data = df, ci = conf_level)
-  es <- tibble::as_tibble(es)[1, , drop = FALSE]
 
-  spec$fitted$es_value <- es$Hedges_g
-  spec$fitted$es_conf_low <- es$CI_low
-  spec$fitted$es_conf_high <- es$CI_high
-  spec$fitted$es_metric <- "Hedges_g"
-  cli::cli_inform("Effect size added: Hedges' g.")
+  engine <- spec$fitted$engine %||% ""
+  effect <- match.arg(effect, c("default", "cohens_d"))
+  es <- switch(
+    engine,
+    student_t = {
+      out <- effectsize::cohens_d(
+        outcome ~ group,
+        data = df,
+        ci = conf_level,
+        hedges.correction = FALSE
+      )
+      list(value = out$Cohens_d, low = out$CI_low, high = out$CI_high,
+           metric = "Cohens_d")
+    },
+    welch_t = {
+      if (effect == "cohens_d") {
+        out <- effectsize::cohens_d(
+          outcome ~ group,
+          data = df,
+          ci = conf_level,
+          hedges.correction = FALSE
+        )
+        list(value = out$Cohens_d, low = out$CI_low, high = out$CI_high,
+             metric = "Cohens_d")
+      } else {
+        out <- effectsize::hedges_g(
+          outcome ~ group,
+          data = df,
+          ci = conf_level
+        )
+        list(value = out$Hedges_g, low = out$CI_low, high = out$CI_high,
+             metric = "Hedges_g")
+      }
+    },
+    mann_whitney = {
+      out <- effectsize::rank_biserial(
+        outcome ~ group,
+        data = df,
+        ci = conf_level
+      )
+      list(
+        value = out$Rank_Biserial,
+        low = out$CI_low,
+        high = out$CI_high,
+        metric = "r_Wilcoxon"
+      )
+    },
+    {
+      out <- effectsize::hedges_g(
+        outcome ~ group,
+        data = df,
+        ci = conf_level
+      )
+      cli::cli_warn("Unknown engine; defaulting to Hedges' g.")
+      list(value = out$Hedges_g, low = out$CI_low, high = out$CI_high,
+           metric = "Hedges_g")
+    }
+  )
+
+  spec$fitted$es_value <- es$value
+  spec$fitted$es_conf_low <- es$low
+  spec$fitted$es_conf_high <- es$high
+  spec$fitted$es_metric <- es$metric
+  cli::cli_inform("Effect size added: {es$metric}.")
   spec
 }

--- a/man/effects.Rd
+++ b/man/effects.Rd
@@ -4,7 +4,7 @@
 \alias{effects}
 \title{Add an effect size to a fitted comparison}
 \usage{
-effects(spec, conf_level = 0.95)
+effects(spec, conf_level = 0.95, effect = "default")
 }
 \arguments{
 \item{spec}{A \code{comp_spec} created by \code{\link[=comp_spec]{comp_spec()}} and already fitted
@@ -13,29 +13,43 @@ numeric outcome and a two‑level group.}
 
 \item{conf_level}{Confidence level for the interval (numeric in (0, 1),
 default \code{0.95}).}
+
+\item{effect}{Optional override for some engines. Currently, only
+\code{effect = "cohens_d"} is supported for the \code{welch_t} engine to
+compute Cohen's \emph{d} instead of Hedges' \emph{g}.}
 }
 \value{
 The input \code{spec}, updated in place with effect‑size fields in
 \code{spec$fitted}: \code{es_value}, \code{es_conf_low}, \code{es_conf_high}, \code{es_metric}.
 }
 \description{
-Compute Hedges' \emph{g} (with a confidence interval) for a two‑group,
-numeric outcome and store it on the \code{comp_spec}. This is a
-post‑fit step that reads from \code{spec$fitted} and writes the following:
-\code{es_value}, \code{es_conf_low}, \code{es_conf_high}, and \code{es_metric} (set to
-\code{"Hedges_g"}).
+Compute an effect size (with a confidence interval) for a two‑group,
+numeric outcome based on the inferential engine stored in
+\code{spec$fitted$engine}. Supported tests map to the following metrics:
 }
 \details{
 \itemize{
+\item \code{"student_t"}: Cohen's \emph{d} (no Hedges correction)
+\item \code{"welch_t"}: Hedges' \emph{g} (default) or Cohen's \emph{d} when
+\code{effect = "cohens_d"}
+\item \code{"mann_whitney"}: Wilcoxon \emph{r} (rank biserial)
+}
+
+The function reads from \code{spec$fitted} and writes \code{es_value},
+\code{es_conf_low}, \code{es_conf_high}, and \code{es_metric} before returning \code{spec}.
+\itemize{
 \item Supported design: two‑group comparison with a \strong{numeric} outcome.
-\item Backend: \href{https://easystats.github.io/effectsize/}{\code{effectsize::hedges_g()}}.
+\item Backend functions from the
+\href{https://easystats.github.io/effectsize/}{\code{effectsize}} package
+(e.g., \code{hedges_g()}, \code{cohens_d()}, \code{rank_biserial()}).
 \item If the \strong{effectsize} package is not installed, a warning is issued
 and the input \code{spec} is returned unchanged.
 }
 
 The function selects \code{spec$data_prepared} when available, otherwise
 falls back to \code{spec$data_raw}. It standardizes inputs internally and
-then calls \code{effectsize::hedges_g(outcome ~ group, ...)}.
+then calls the appropriate effect size function based on
+\code{spec$fitted$engine}.
 }
 \examples{
 # Minimal workflow (illustrative):


### PR DESCRIPTION
## Summary
- Add engine-aware effect size computation, selecting Cohen's *d*, Hedges' *g*, or Wilcoxon *r* based on `spec$fitted$engine`.
- Allow optional `effect = "cohens_d"` override for Welch *t* tests.
- Update documentation for new effect size options.

## Testing
- `R CMD check --no-manual --as-cran .` *(fails: Required fields missing or empty: 'Author' 'Maintainer')*

------
https://chatgpt.com/codex/tasks/task_e_689b50bcbff88325876bae824efa17dd