### PR TITLE
Add paired test engines and support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     ggplot2,
     purrr,
     rlang,
-    tibble
+    tibble,
+    tidyr
 Suggests:
     broom,
     knitr,

--- a/tests/testthat/test-effects.R
+++ b/tests/testthat/test-effects.R
@@ -78,6 +78,42 @@ test_that("effects() computes rank biserial for mann_whitney engine", {
   expect_type(out$fitted$es_conf_high, "double")
 })
 
+# Paired t and Wilcoxon signed-rank ----
+
+test_that("effects() computes Cohen's d for paired_t engine", {
+  df <- tibble::tibble(
+    id = rep(1:5, each = 2),
+    group = factor(rep(c("A", "B"), times = 5)),
+    outcome = c(1, 2, 2, 3, 3, 4, 4, 5, 5, 6)
+  )
+  out <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("paired") |>
+    set_outcome_type("numeric") |>
+    set_engine("paired_t") |>
+    test() |>
+    effects(conf_level = 0.90)
+  expect_equal(out$fitted$es_metric, "Cohens_d")
+  expect_type(out$fitted$es_value, "double")
+})
+
+test_that("effects() computes rank biserial for wilcoxon_signed_rank engine", {
+  df <- tibble::tibble(
+    id = rep(1:6, each = 2),
+    group = factor(rep(c("A", "B"), times = 6)),
+    outcome = c(1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7)
+  )
+  out <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("paired") |>
+    set_outcome_type("numeric") |>
+    set_engine("wilcoxon_signed_rank") |>
+    test() |>
+    effects(conf_level = 0.90)
+  expect_equal(out$fitted$es_metric, "r_Wilcoxon")
+  expect_type(out$fitted$es_value, "double")
+})
+
 # Unknown engines fallback to Hedges' g with a warning ----
 test_that("effects() defaults to Hedges g for unknown engine (with warning)", {
   fit <- comp_spec(mtcars) |>

--- a/tests/testthat/test-engines.R
+++ b/tests/testthat/test-engines.R
@@ -6,7 +6,7 @@
 # helper to build meta object used by engines
 make_meta <- function() {
   list(
-    roles = list(outcome = "outcome", group = "group"),
+    roles = list(outcome = "outcome", group = "group", id = "id"),
     diagnostics = list(notes = character()),
     settings = list()
   )
@@ -14,7 +14,10 @@ make_meta <- function() {
 
 test_that("engine registry lists available engines", {
   engines <- tidycomp:::.tidycomp_engines()
-  expect_named(engines, c("welch_t", "student_t", "mann_whitney"))
+  expect_named(
+    engines,
+    c("welch_t", "student_t", "mann_whitney", "paired_t", "wilcoxon_signed_rank")
+  )
   purrr::walk(engines, ~ expect_true(is.function(.x)))
 })
 
@@ -73,6 +76,63 @@ test_that("Mann-Whitney engine matches stats::wilcox.test", {
     exact = FALSE,
     correct = TRUE
   )
+  expect_s3_class(res, "tbl_df")
+  expect_equal(res$statistic, unname(base$statistic))
+  expect_equal(res$p.value, unname(base$p.value))
+  expect_equal(res$estimate, unname(base$estimate))
+  expect_equal(
+    c(res$conf.low, res$conf.high),
+    unname(base$conf.int),
+    ignore_attr = TRUE
+  )
+})
+
+# Paired t-test ---------------------------------------------------------------
+
+test_that("paired t engine matches stats::t.test with paired = TRUE", {
+  df <- tibble::tibble(
+    id = rep(1:5, each = 2),
+    outcome = c(1, 2, 2, 3, 3, 4, 4, 5, 5, 6),
+    group = factor(rep(c("A", "B"), times = 5))
+  )
+  meta <- make_meta()
+  res <- tidycomp:::engine_paired_t(df, meta)
+  wide <- tidyr::pivot_wider(
+    df,
+    id_cols = "id",
+    names_from = "group",
+    values_from = "outcome"
+  )
+  base <- stats::t.test(wide$B, wide$A, paired = TRUE)
+  expect_s3_class(res, "tbl_df")
+  expect_equal(res$statistic, unname(base$statistic))
+  expect_equal(res$df, unname(base$parameter))
+  expect_equal(res$p.value, unname(base$p.value))
+  expect_equal(res$estimate, unname(base$estimate))
+  expect_equal(
+    c(res$conf.low, res$conf.high),
+    unname(base$conf.int),
+    ignore_attr = TRUE
+  )
+})
+
+# Wilcoxon signed-rank --------------------------------------------------------
+
+test_that("wilcoxon_signed_rank engine matches stats::wilcox.test paired", {
+  df <- tibble::tibble(
+    id = rep(1:6, each = 2),
+    outcome = c(1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7),
+    group = factor(rep(c("A", "B"), times = 6))
+  )
+  meta <- make_meta()
+  res <- tidycomp:::engine_wilcoxon_signed_rank(df, meta)
+  wide <- tidyr::pivot_wider(
+    df,
+    id_cols = "id",
+    names_from = "group",
+    values_from = "outcome"
+  )
+  base <- stats::wilcox.test(wide$B, wide$A, paired = TRUE, conf.int = TRUE, exact = FALSE, correct = TRUE)
   expect_s3_class(res, "tbl_df")
   expect_equal(res$statistic, unname(base$statistic))
   expect_equal(res$p.value, unname(base$p.value))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -82,6 +82,33 @@ test_that(".standardize_two_group_numeric validates input types", {
 })
 
 # -----------------------------------------------------------------------------
+# .standardize_paired_numeric()
+# -----------------------------------------------------------------------------
+
+test_that(".standardize_paired_numeric returns wide tibble", {
+  data <- tibble::tibble(
+    id = rep(1:3, each = 2),
+    g = factor(rep(c("A", "B"), times = 3)),
+    y = c(1, 2, 3, 4, 5, 6)
+  )
+  res <- tidycomp:::.standardize_paired_numeric(data, "y", "g", "id")
+  expect_s3_class(res, "tbl_df")
+  expect_equal(ncol(res), 2)
+})
+
+test_that(".standardize_paired_numeric validates pairing", {
+  data_bad <- tibble::tibble(
+    id = c(1, 1, 2),
+    g = factor(c("A", "A", "B")),
+    y = 1:3
+  )
+  expect_error(
+    tidycomp:::.standardize_paired_numeric(data_bad, "y", "g", "id"),
+    "Each id must have one observation"
+  )
+})
+
+# -----------------------------------------------------------------------------
 # .flag_outliers()
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- extend `test()` to handle `design = "paired"` with required `id` role
- add paired t-test and Wilcoxon signed-rank engines and effect size support
- expand utilities and unit tests for paired comparisons

## Testing
- `R -q -e 'devtools::test()'` *(fails: there is no package called ‘devtools’)*


------
https://chatgpt.com/codex/tasks/task_e_689c7781fdf48325a12b43dbab066205