### PR TITLE
Add equal and Welch one-way ANOVA engines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * Added paired 2-group comparisons: `engine_paired_t` and `engine_wilcoxon_signed_rank`.
 * Amended tests to account for new paired engines.
-* Added multi-group comparisons: `engine_anova_oneway`, `engine_kruskal_wallis`,
+* Added multi-group comparisons: `engine_anova_oneway_equal`,
+  `engine_anova_oneway_welch`, `engine_kruskal_wallis`,
   `engine_anova_repeated`, and `engine_friedman` with corresponding diagnostics.
 
 # tidycomp 0.1.1

--- a/R/test.R
+++ b/R/test.R
@@ -105,12 +105,12 @@ test <- function(spec) {
       if (g_levels > 2) {
         engine <- switch(
           spec$strategy,
-          auto = "anova_oneway",
-          pragmatic = "anova_oneway",
-          parametric = "anova_oneway",
-          robust = "anova_oneway",
-          permutation = "anova_oneway",
-          "anova_oneway"
+          auto = "anova_oneway_welch",
+          pragmatic = "anova_oneway_welch",
+          parametric = "anova_oneway_equal",
+          robust = "anova_oneway_welch",
+          permutation = "anova_oneway_welch",
+          "anova_oneway_welch"
         )
         diag <- spec$diagnostics
         if (!is.null(diag)) {

--- a/tests/testthat/test-generics.R
+++ b/tests/testthat/test-generics.R
@@ -11,7 +11,6 @@ result <- list(
   estimate = 1,
   conf.low = 0.5,
   conf.high = 1.5,
-  fitted = list(estimate = 1, conf.low = 0.5, conf.high = 1.5),
   notes = list(character())
 )
 class(result) <- c("comp_result", "list")

--- a/tests/testthat/test-test.R
+++ b/tests/testthat/test-test.R
@@ -93,7 +93,7 @@ test_that("default engine is welch_t and warns if diagnostics missing", {
   expect_equal(res$fitted$engine, "welch_t")
 })
 
-test_that("independent design with >2 groups defaults to anova_oneway", {
+test_that("independent design with >2 groups defaults to anova_oneway_welch", {
   df <- tibble::tibble(
     outcome = c(1,2,3,4,5,6,7,8,9),
     group = factor(rep(c("A","B","C"), each = 3))
@@ -105,7 +105,23 @@ test_that("independent design with >2 groups defaults to anova_oneway", {
       set_outcome_type("numeric")
   )
   res <- suppressMessages(test(spec))
-  expect_equal(res$fitted$engine, "anova_oneway")
+  expect_equal(res$fitted$engine, "anova_oneway_welch")
+})
+
+test_that("parametric strategy uses anova_oneway_equal engine for >2 groups", {
+  df <- tibble::tibble(
+    outcome = c(1,2,3,4,5,6,7,8,9),
+    group = factor(rep(c("A","B","C"), each = 3))
+  )
+  spec <- suppressMessages(
+    comp_spec(df) |>
+      set_roles(outcome = outcome, group = group) |>
+      set_design("independent") |>
+      set_outcome_type("numeric") |>
+      set_strategy("parametric")
+  )
+  res <- suppressMessages(test(spec))
+  expect_equal(res$fitted$engine, "anova_oneway_equal")
 })
 
 test_that("parametric strategy uses student_t engine", {


### PR DESCRIPTION
## Summary
- Provide separate one-way ANOVA engines for equal and unequal variances
- Register new engines and update default strategy mapping
- Expand engine tests and defaults for multi-group comparisons

## Testing
- `Rscript -e 'devtools::test()'`

------
https://chatgpt.com/codex/tasks/task_e_689cc4499d2c8325850493bfd3209f65