### PR TITLE
Handle multi-group effect size standardization

### DIFF
--- a/R/effects.R
+++ b/R/effects.R
@@ -73,12 +73,26 @@ effects <- function(spec, conf_level = 0.95, effect = "default") {
   }
 
   data <- spec$data_prepared %||% spec$data_raw
+  engine <- spec$fitted$engine %||% ""
+  multi_group_engines <- c(
+    "kruskal_wallis",
+    "anova_oneway_equal",
+    "anova_oneway_welch",
+    "anova_repeated",
+    "friedman"
+  )
   df <- if (identical(spec$design, "paired")) {
     .standardize_paired_numeric(
       data,
       spec$roles$outcome,
       spec$roles$group,
       spec$roles$id
+    )
+  } else if (engine %in% multi_group_engines) {
+    .standardize_multi_group_numeric(
+      data,
+      spec$roles$outcome,
+      spec$roles$group
     )
   } else {
     .standardize_two_group_numeric(
@@ -87,8 +101,6 @@ effects <- function(spec, conf_level = 0.95, effect = "default") {
       spec$roles$group
     )
   }
-
-  engine <- spec$fitted$engine %||% ""
   effect <- match.arg(effect, c("default", "cohens_d"))
   es <- switch(
     engine,

--- a/tests/testthat/test-effects.R
+++ b/tests/testthat/test-effects.R
@@ -137,6 +137,19 @@ test_that("effects() defaults to Hedges g for unknown engine (with warning)", {
   expect_type(out$fitted$es_conf_high, "double")
 })
 
+# Multi-group engines are standardised correctly ----
+test_that("effects() standardizes data for multi-group engines", {
+  out <- comp_spec(iris) |>
+    set_roles(outcome = Sepal.Length, group = Species) |>
+    set_design("independent") |>
+    set_outcome_type("numeric") |>
+    set_engine("kruskal_wallis") |>
+    test() |>
+    effects(conf_level = 0.90)
+
+  expect_type(out$fitted$es_value, "double")
+})
+
 # When effectsize package is not available ----
 test_that("effects() warns and returns input when effectsize is absent", {
   testthat::local_mocked_bindings(


### PR DESCRIPTION
## Summary
- Detect multi-group engines in `effects()` and standardize with `.standardize_multi_group_numeric`
- Preserve paired designs by prioritizing `.standardize_paired_numeric`
- Test multi-group standardization in `effects()`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_689d0ea5146c83259a62a8d5c102795a