### PR TITLE
Add effect size support for multi-group engines

### DIFF
--- a/R/effects.R
+++ b/R/effects.R
@@ -1,7 +1,7 @@
 #' Add an effect size to a fitted comparison
 #'
-#' Compute an effect size (with a confidence interval) for a two‑group,
-#' numeric outcome based on the inferential engine stored in
+#' Compute an effect size (with a confidence interval) for a numeric
+#' outcome based on the inferential engine stored in
 #' `spec$fitted$engine`. Supported tests map to the following metrics:
 #'
 #' - `"student_t"`: Cohen's *d* (no Hedges correction)
@@ -10,24 +10,35 @@
 #' - `"mann_whitney"`: Wilcoxon *r* (rank biserial)
 #' - `"paired_t"`: Cohen's *d* for paired samples
 #' - `"wilcoxon_signed_rank"`: Wilcoxon *r* (rank biserial)
+#' - `"kruskal_wallis"`: Rank *eta*² (default) or rank *epsilon*² when
+#'   `effect = "epsilon_squared"`
+#' - `"anova_oneway_equal"` / `"anova_oneway_welch"`: *eta*² (default) or
+#'   *omega*² when `effect = "omega_squared"`
+#' - `"anova_repeated"`: partial *eta*²
+#' - `"friedman"`: Kendall's *W*
 #'
 #' The function reads from `spec$fitted` and writes `es_value`,
 #' `es_conf_low`, `es_conf_high`, and `es_metric` before returning `spec`.
 #'
 #' @param spec A `comp_spec` created by [comp_spec()] and already fitted
 #'   via `test()` (i.e., `spec$fitted` must exist). Roles must include a
-#'   numeric outcome and a two‑level group.
+#'   numeric outcome and an appropriate group (two-level for two-group
+#'   engines, multi-level for ANOVA/Kruskal-Wallis, or `id` for repeated
+#'   measures).
 #' @param conf_level Confidence level for the interval (numeric in (0, 1),
 #'   default `0.95`).
-#' @param effect Optional override for some engines. Currently, only
-#'   `effect = "cohens_d"` is supported for the `welch_t` engine to
-#'   compute Cohen's *d* instead of Hedges' *g*.
+#' @param effect Optional override for some engines. Supported overrides
+#'   are `effect = "cohens_d"` for the `welch_t` engine,
+#'   `effect = "epsilon_squared"` for `kruskal_wallis`, and
+#'   `effect = "omega_squared"` for one-way ANOVA engines.
 #'
 #' @details
-#' - Supported design: two‑group comparison with a **numeric** outcome.
+#' - Supported designs: two-group, multi-group, or repeated measures with a
+#'   **numeric** outcome.
 #' - Backend functions from the
 #'   [`effectsize`](https://easystats.github.io/effectsize/) package
-#'   (e.g., `hedges_g()`, `cohens_d()`, `rank_biserial()`).
+#'   (e.g., `hedges_g()`, `cohens_d()`, `eta_squared()`,
+#'   `rank_epsilon_squared()`).
 #' - If the **effectsize** package is not installed, a warning is issued
 #'   and the input `spec` is returned unchanged.
 #'
@@ -72,13 +83,29 @@ effects <- function(spec, conf_level = 0.95, effect = "default") {
     return(spec)
   }
 
+  engine <- spec$fitted$engine %||% ""
+  effect <- match.arg(effect, c("default", "cohens_d", "omega_squared", "epsilon_squared"))
+
   data <- spec$data_prepared %||% spec$data_raw
-  df <- if (identical(spec$design, "paired")) {
+  df <- if (identical(spec$design, "repeated")) {
+    .standardize_repeated_numeric(
+      data,
+      spec$roles$outcome,
+      spec$roles$group,
+      spec$roles$id
+    )
+  } else if (identical(spec$design, "paired")) {
     .standardize_paired_numeric(
       data,
       spec$roles$outcome,
       spec$roles$group,
       spec$roles$id
+    )
+  } else if (engine %in% c("kruskal_wallis", "anova_oneway_equal", "anova_oneway_welch")) {
+    .standardize_multi_group_numeric(
+      data,
+      spec$roles$outcome,
+      spec$roles$group
     )
   } else {
     .standardize_two_group_numeric(
@@ -87,9 +114,6 @@ effects <- function(spec, conf_level = 0.95, effect = "default") {
       spec$roles$group
     )
   }
-
-  engine <- spec$fitted$engine %||% ""
-  effect <- match.arg(effect, c("default", "cohens_d"))
   es <- switch(
     engine,
     student_t = {
@@ -145,6 +169,97 @@ effects <- function(spec, conf_level = 0.95, effect = "default") {
         low = out$CI_low,
         high = out$CI_high,
         metric = "r_Wilcoxon"
+      )
+    },
+    kruskal_wallis = {
+      if (effect == "epsilon_squared") {
+        out <- effectsize::rank_epsilon_squared(
+          outcome ~ group,
+          data = df,
+          ci = conf_level
+        )
+        list(
+          value = out$rank_epsilon_squared,
+          low = out$CI_low,
+          high = out$CI_high,
+          metric = "epsilon_squared"
+        )
+      } else {
+        out <- effectsize::rank_eta_squared(
+          outcome ~ group,
+          data = df,
+          ci = conf_level
+        )
+        list(
+          value = out$rank_eta_squared,
+          low = out$CI_low,
+          high = out$CI_high,
+          metric = "eta_squared"
+        )
+      }
+    },
+    anova_oneway_equal = {
+      mod <- stats::aov(outcome ~ group, data = df)
+      if (effect == "omega_squared") {
+        out <- effectsize::omega_squared(mod, ci = conf_level)
+        list(
+          value = out$Omega2,
+          low = out$CI_low,
+          high = out$CI_high,
+          metric = "omega_squared"
+        )
+      } else {
+        out <- effectsize::eta_squared(mod, ci = conf_level)
+        list(
+          value = out$Eta2,
+          low = out$CI_low,
+          high = out$CI_high,
+          metric = "eta_squared"
+        )
+      }
+    },
+    anova_oneway_welch = {
+      mod <- stats::aov(outcome ~ group, data = df)
+      if (effect == "omega_squared") {
+        out <- effectsize::omega_squared(mod, ci = conf_level)
+        list(
+          value = out$Omega2,
+          low = out$CI_low,
+          high = out$CI_high,
+          metric = "omega_squared"
+        )
+      } else {
+        out <- effectsize::eta_squared(mod, ci = conf_level)
+        list(
+          value = out$Eta2,
+          low = out$CI_low,
+          high = out$CI_high,
+          metric = "eta_squared"
+        )
+      }
+    },
+    anova_repeated = {
+      mod <- stats::aov(outcome ~ group + Error(id/group), data = df)
+      out <- effectsize::eta_squared(mod, partial = TRUE, ci = conf_level)
+      row <- out[out$Group == "Within" & out$Parameter == "group", ]
+      list(
+        value = row$Eta2_partial,
+        low = row$CI_low,
+        high = row$CI_high,
+        metric = "partial_eta_squared"
+      )
+    },
+    friedman = {
+      out <- effectsize::kendalls_w(
+        outcome ~ group | id,
+        data = df,
+        ci = conf_level
+      )
+      list(
+        value = out$Kendalls_W,
+        low = out$CI_low,
+        high = out$CI_high,
+        metric = "Kendalls_W"
       )
     },
     paired_t = {

--- a/man/effects.Rd
+++ b/man/effects.Rd
@@ -9,22 +9,25 @@ effects(spec, conf_level = 0.95, effect = "default")
 \arguments{
 \item{spec}{A \code{comp_spec} created by \code{\link[=comp_spec]{comp_spec()}} and already fitted
 via \code{test()} (i.e., \code{spec$fitted} must exist). Roles must include a
-numeric outcome and a two‑level group.}
+numeric outcome and an appropriate grouping structure (two levels for
+two-group tests, multiple levels for ANOVA/Kruskal-Wallis, or an \code{id}
+column for repeated measures).}
 
 \item{conf_level}{Confidence level for the interval (numeric in (0, 1),
 default \code{0.95}).}
 
-\item{effect}{Optional override for some engines. Currently, only
-\code{effect = "cohens_d"} is supported for the \code{welch_t} engine to
-compute Cohen's \emph{d} instead of Hedges' \emph{g}.}
+\item{effect}{Optional override for some engines. Supported overrides are
+\code{effect = "cohens_d"} for \code{welch_t}, \code{effect = "epsilon_squared"}
+for \code{kruskal_wallis}, and \code{effect = "omega_squared"} for one-way
+ANOVA engines.}
 }
 \value{
 The input \code{spec}, updated in place with effect‑size fields in
 \code{spec$fitted}: \code{es_value}, \code{es_conf_low}, \code{es_conf_high}, \code{es_metric}.
 }
 \description{
-Compute an effect size (with a confidence interval) for a two‑group,
-numeric outcome based on the inferential engine stored in
+Compute an effect size (with a confidence interval) for a numeric
+outcome based on the inferential engine stored in
 \code{spec$fitted$engine}. Supported tests map to the following metrics:
 }
 \details{
@@ -35,15 +38,23 @@ numeric outcome based on the inferential engine stored in
 \item \code{"mann_whitney"}: Wilcoxon \emph{r} (rank biserial)
 \item \code{"paired_t"}: Cohen's \emph{d} for paired samples
 \item \code{"wilcoxon_signed_rank"}: Wilcoxon \emph{r} (rank biserial)
+\item \code{"kruskal_wallis"}: Rank \emph{eta}\^2 (default) or rank
+\emph{epsilon}\^2 when \code{effect = "epsilon_squared"}
+\item \code{"anova_oneway_equal"} / \code{"anova_oneway_welch"}: \emph{eta}\^2
+(default) or \emph{omega}\^2 when \code{effect = "omega_squared"}
+\item \code{"anova_repeated"}: partial \emph{eta}\^2
+\item \code{"friedman"}: Kendall's \emph{W}
 }
 
 The function reads from \code{spec$fitted} and writes \code{es_value},
 \code{es_conf_low}, \code{es_conf_high}, and \code{es_metric} before returning \code{spec}.
 \itemize{
-\item Supported design: two‑group comparison with a \strong{numeric} outcome.
+\item Supported designs: two-group, multi-group, or repeated measures with a
+\strong{numeric} outcome.
 \item Backend functions from the
 \href{https://easystats.github.io/effectsize/}{\code{effectsize}} package
-(e.g., \code{hedges_g()}, \code{cohens_d()}, \code{rank_biserial()}).
+(e.g., \code{hedges_g()}, \code{cohens_d()}, \code{eta_squared()},
+\code{rank_epsilon_squared()}).
 \item If the \strong{effectsize} package is not installed, a warning is issued
 and the input \code{spec} is returned unchanged.
 }

--- a/tests/testthat/test-effects.R
+++ b/tests/testthat/test-effects.R
@@ -78,6 +78,105 @@ test_that("effects() computes rank biserial for mann_whitney engine", {
   expect_type(out$fitted$es_conf_high, "double")
 })
 
+# Multi-group engines ----
+
+test_that("effects() computes eta_squared for kruskal_wallis engine", {
+  out <-
+    comp_spec(iris) |>
+    set_roles(outcome = Sepal.Length, group = Species) |>
+    set_design("independent") |>
+    set_outcome_type("numeric") |>
+    set_engine("kruskal_wallis") |>
+    test() |>
+    effects(conf_level = 0.90)
+
+  expect_equal(out$fitted$es_metric, "eta_squared")
+  expect_type(out$fitted$es_value, "double")
+  expect_type(out$fitted$es_conf_low, "double")
+  expect_type(out$fitted$es_conf_high, "double")
+})
+
+test_that("effects() allows epsilon_squared for kruskal_wallis", {
+  out <-
+    comp_spec(iris) |>
+    set_roles(outcome = Sepal.Length, group = Species) |>
+    set_design("independent") |>
+    set_outcome_type("numeric") |>
+    set_engine("kruskal_wallis") |>
+    test() |>
+    effects(effect = "epsilon_squared", conf_level = 0.90)
+
+  expect_equal(out$fitted$es_metric, "epsilon_squared")
+  expect_type(out$fitted$es_value, "double")
+  expect_type(out$fitted$es_conf_low, "double")
+})
+
+test_that("effects() computes eta_squared for anova_oneway_equal engine", {
+  out <-
+    comp_spec(iris) |>
+    set_roles(outcome = Sepal.Length, group = Species) |>
+    set_design("independent") |>
+    set_outcome_type("numeric") |>
+    set_engine("anova_oneway_equal") |>
+    test() |>
+    effects(conf_level = 0.90)
+
+  expect_equal(out$fitted$es_metric, "eta_squared")
+  expect_type(out$fitted$es_value, "double")
+})
+
+test_that("effects() allows omega_squared for anova_oneway_welch", {
+  out <-
+    comp_spec(iris) |>
+    set_roles(outcome = Sepal.Length, group = Species) |>
+    set_design("independent") |>
+    set_outcome_type("numeric") |>
+    set_engine("anova_oneway_welch") |>
+    test() |>
+    effects(effect = "omega_squared", conf_level = 0.90)
+
+  expect_equal(out$fitted$es_metric, "omega_squared")
+  expect_type(out$fitted$es_value, "double")
+})
+
+test_that("effects() computes partial eta squared for anova_repeated engine", {
+  set.seed(123)
+  df <- tibble::tibble(
+    id = rep(1:6, each = 3),
+    group = factor(rep(c("A", "B", "C"), times = 6)),
+    outcome = rnorm(18)
+  )
+  out <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("repeated") |>
+    set_outcome_type("numeric") |>
+    set_engine("anova_repeated") |>
+    test() |>
+    effects(conf_level = 0.90)
+
+  expect_equal(out$fitted$es_metric, "partial_eta_squared")
+  expect_type(out$fitted$es_value, "double")
+})
+
+test_that("effects() computes Kendalls_W for friedman engine", {
+  set.seed(123)
+  df <- tibble::tibble(
+    id = rep(1:6, each = 3),
+    group = factor(rep(c("A", "B", "C"), times = 6)),
+    outcome = rnorm(18)
+  )
+  out <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("repeated") |>
+    set_outcome_type("numeric") |>
+    set_engine("friedman") |>
+    test() |>
+    effects(conf_level = 0.90)
+
+  expect_equal(out$fitted$es_metric, "Kendalls_W")
+  expect_type(out$fitted$es_value, "double")
+})
+
 # Paired t and Wilcoxon signed-rank ----
 
 test_that("effects() computes Cohen's d for paired_t engine", {


### PR DESCRIPTION
## Summary
- handle effect sizes for kruskal-wallis, one-way ANOVA, repeated-measures ANOVA, and friedman engines
- allow eta/epsilon squared and omega squared overrides for relevant engines
- test coverage for multi-group effect sizes
- use `partial_eta_squared` metric for repeated measures ANOVA

## Testing
- `R --vanilla -q -e 'testthat::test_local()'` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_689d0ea65e2c832582f47eb1fadaaf7c