### PR TITLE
Add effect sizes for multi-group engines

### DIFF
--- a/R/effects.R
+++ b/R/effects.R
@@ -1,30 +1,34 @@
 #' Add an effect size to a fitted comparison
 #'
-#' Compute an effect size (with a confidence interval) for a two‑group,
-#' numeric outcome based on the inferential engine stored in
-#' `spec$fitted$engine`. Supported tests map to the following metrics:
+#' Compute an effect size (with a confidence interval) for a numeric outcome
+#' based on the inferential engine stored in `spec$fitted$engine`. Supported
+#' tests map to the following default metrics:
 #'
-#' - `"student_t"`: Cohen's *d* (no Hedges correction)
-#' - `"welch_t"`: Hedges' *g* (default) or Cohen's *d* when
-#'   `effect = "cohens_d"`
+#' - `"student_t"`: Cohen's *d*
+#' - `"welch_t"`: Hedges' *g*
 #' - `"mann_whitney"`: Wilcoxon *r* (rank biserial)
 #' - `"paired_t"`: Cohen's *d* for paired samples
 #' - `"wilcoxon_signed_rank"`: Wilcoxon *r* (rank biserial)
+#' - `"anova_oneway_equal"`: Eta squared
+#' - `"anova_oneway_welch"`: Omega squared
+#' - `"kruskal_wallis"`: Epsilon squared
 #'
 #' The function reads from `spec$fitted` and writes `es_value`,
 #' `es_conf_low`, `es_conf_high`, and `es_metric` before returning `spec`.
 #'
 #' @param spec A `comp_spec` created by [comp_spec()] and already fitted
 #'   via `test()` (i.e., `spec$fitted` must exist). Roles must include a
-#'   numeric outcome and a two‑level group.
+#'   numeric outcome and a grouping variable.
 #' @param conf_level Confidence level for the interval (numeric in (0, 1),
 #'   default `0.95`).
-#' @param effect Optional override for some engines. Currently, only
-#'   `effect = "cohens_d"` is supported for the `welch_t` engine to
-#'   compute Cohen's *d* instead of Hedges' *g*.
+#' @param effect Optional name of an effect size function from the
+#'   **effectsize** package. The default (`"default"`) selects a sensible
+#'   metric for the chosen engine. Any exported function from **effectsize**
+#'   (e.g., `"cohens_d"`, `"omega_squared"`) may be provided.
 #'
 #' @details
-#' - Supported design: two‑group comparison with a **numeric** outcome.
+#' - Supported designs: two-group and multi-group comparisons with a
+#'   **numeric** outcome.
 #' - Backend functions from the
 #'   [`effectsize`](https://easystats.github.io/effectsize/) package
 #'   (e.g., `hedges_g()`, `cohens_d()`, `rank_biserial()`).
@@ -73,131 +77,74 @@ effects <- function(spec, conf_level = 0.95, effect = "default") {
   }
 
   data <- spec$data_prepared %||% spec$data_raw
-  df <- if (identical(spec$design, "paired")) {
-    .standardize_paired_numeric(
+  engine <- spec$fitted$engine %||% ""
+
+  default_map <- list(
+    student_t = "cohens_d",
+    welch_t = "hedges_g",
+    mann_whitney = "rank_biserial",
+    paired_t = "cohens_d",
+    wilcoxon_signed_rank = "rank_biserial",
+    anova_oneway_equal = "eta_squared",
+    anova_oneway_welch = "omega_squared",
+    kruskal_wallis = "epsilon_squared"
+  )
+
+  effect <- effect %||% "default"
+  if (identical(effect, "default")) {
+    effect <- default_map[[engine]] %||% "hedges_g"
+    if (is.null(default_map[[engine]])) {
+      cli::cli_warn("Unknown engine; defaulting to Hedges' g.")
+    }
+  }
+
+  if (!effect %in% getNamespaceExports("effectsize")) {
+    cli::cli_abort("Unknown effect size `{effect}` from package 'effectsize'.")
+  }
+
+  if (identical(spec$design, "paired")) {
+    df <- .standardize_paired_numeric(
       data,
       spec$roles$outcome,
       spec$roles$group,
       spec$roles$id
     )
-  } else {
-    .standardize_two_group_numeric(
+    g <- names(df)
+    args <- list(df[[g[2]]], df[[g[1]]], paired = TRUE, ci = conf_level)
+  } else if (engine %in% c("anova_oneway_equal", "anova_oneway_welch", "kruskal_wallis")) {
+    df <- .standardize_multi_group_numeric(
       data,
       spec$roles$outcome,
       spec$roles$group
     )
+    fit <- switch(
+      engine,
+      anova_oneway_equal = stats::aov(outcome ~ group, data = df),
+      anova_oneway_welch = stats::oneway.test(outcome ~ group, data = df),
+      kruskal_wallis = stats::kruskal.test(outcome ~ group, data = df)
+    )
+    args <- list(fit, ci = conf_level)
+  } else {
+    df <- .standardize_two_group_numeric(
+      data,
+      spec$roles$outcome,
+      spec$roles$group
+    )
+    args <- list(outcome ~ group, data = df, ci = conf_level)
   }
 
-  engine <- spec$fitted$engine %||% ""
-  effect <- match.arg(effect, c("default", "cohens_d"))
-  es <- switch(
-    engine,
-    student_t = {
-      out <- effectsize::cohens_d(
-        outcome ~ group,
-        data = df,
-        ci = conf_level,
-        hedges.correction = FALSE
-      )
-      list(
-        value = out$Cohens_d,
-        low = out$CI_low,
-        high = out$CI_high,
-        metric = "Cohens_d"
-      )
-    },
-    welch_t = {
-      if (effect == "cohens_d") {
-        out <- effectsize::cohens_d(
-          outcome ~ group,
-          data = df,
-          ci = conf_level,
-          hedges.correction = FALSE
-        )
-        list(
-          value = out$Cohens_d,
-          low = out$CI_low,
-          high = out$CI_high,
-          metric = "Cohens_d"
-        )
-      } else {
-        out <- effectsize::hedges_g(
-          outcome ~ group,
-          data = df,
-          ci = conf_level
-        )
-        list(
-          value = out$Hedges_g,
-          low = out$CI_low,
-          high = out$CI_high,
-          metric = "Hedges_g"
-        )
-      }
-    },
-    mann_whitney = {
-      out <- effectsize::rank_biserial(
-        outcome ~ group,
-        data = df,
-        ci = conf_level
-      )
-      list(
-        value = out$r_rank_biserial,
-        low = out$CI_low,
-        high = out$CI_high,
-        metric = "r_Wilcoxon"
-      )
-    },
-    paired_t = {
-      g <- names(df)
-      out <- effectsize::cohens_d(
-        df[[g[2]]],
-        df[[g[1]]],
-        paired = TRUE,
-        ci = conf_level,
-        hedges.correction = FALSE
-      )
-      list(
-        value = out$Cohens_d,
-        low = out$CI_low,
-        high = out$CI_high,
-        metric = "Cohens_d"
-      )
-    },
-    wilcoxon_signed_rank = {
-      g <- names(df)
-      out <- effectsize::rank_biserial(
-        df[[g[2]]],
-        df[[g[1]]],
-        paired = TRUE,
-        ci = conf_level
-      )
-      list(
-        value = out$r_rank_biserial,
-        low = out$CI_low,
-        high = out$CI_high,
-        metric = "r_Wilcoxon"
-      )
-    },
-    {
-      out <- effectsize::hedges_g(
-        outcome ~ group,
-        data = df,
-        ci = conf_level
-      )
-      cli::cli_warn("Unknown engine; defaulting to Hedges' g.")
-      list(
-        value = out$Hedges_g,
-        low = out$CI_low,
-        high = out$CI_high,
-        metric = "Hedges_g"
-      )
-    }
-  )
+  fun <- getExportedValue("effectsize", effect)
+  out <- do.call(fun, args)
 
-  spec$fitted$es_value <- es$value
-  spec$fitted$es_conf_low <- es$low
-  spec$fitted$es_conf_high <- es$high
-  spec$fitted$es_metric <- es$metric
-  cli::cli_inform("Effect size added: {es$metric}.")
+  metric <- names(out)[1]
+  if (metric == "r_rank_biserial") {
+    metric <- "r_Wilcoxon"
+  }
+
+  spec$fitted$es_value <- unname(out[[1]])
+  spec$fitted$es_conf_low <- out$CI_low %||% NA_real_
+  spec$fitted$es_conf_high <- out$CI_high %||% NA_real_
+  spec$fitted$es_metric <- metric
+  cli::cli_inform("Effect size added: {metric}.")
   spec
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,6 +70,31 @@
   df
 }
 
+#' Standardize multi-group numeric data
+#'
+#' Select and rename the outcome and group columns, validate type, and
+#' coerce the group column to a factor with at least two levels.
+#'
+#' @param data A data frame.
+#' @param outcome,group Character names of validated columns.
+#' @return A tibble with columns `outcome` (numeric) and `group` (factor).
+#' @keywords internal
+#' @noRd
+.standardize_multi_group_numeric <- function(data, outcome, group) {
+  df <- tibble::as_tibble(data[, c(outcome, group)])
+  names(df) <- c("outcome", "group")
+  if (!is.numeric(df$outcome)) {
+    cli::cli_abort("Outcome must be numeric for the current engine.")
+  }
+  if (!is.factor(df$group)) {
+    df$group <- factor(df$group)
+  }
+  if (nlevels(df$group) < 2) {
+    cli::cli_abort("Group must have at least 2 levels for this engine.")
+  }
+  df
+}
+
 #' Standardize paired numeric data with id
 #'
 #' Select outcome, group, and id columns, validate pairing structure, and

--- a/tests/testthat/test-effects.R
+++ b/tests/testthat/test-effects.R
@@ -114,6 +114,68 @@ test_that("effects() computes rank biserial for wilcoxon_signed_rank engine", {
   expect_type(out$fitted$es_value, "double")
 })
 
+# Multi-group engines ----
+
+test_that("effects() computes eta squared for anova_oneway_equal engine", {
+  df <- tibble::tibble(
+    outcome = c(1, 2, 3, 4, 5, 6, 7, 8, 9),
+    group = factor(rep(c("A", "B", "C"), each = 3))
+  )
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group) |>
+    set_design("independent") |>
+    set_outcome_type("numeric")
+  spec$fitted <- list(engine = "anova_oneway_equal")
+  out <- effects(spec, conf_level = 0.90)
+  expect_equal(out$fitted$es_metric, "Eta2")
+  expect_type(out$fitted$es_value, "double")
+})
+
+test_that("effects() computes omega squared for anova_oneway_welch engine", {
+  df <- tibble::tibble(
+    outcome = c(1, 2, 3, 4, 5, 6, 7, 8, 9),
+    group = factor(rep(c("A", "B", "C"), each = 3))
+  )
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group) |>
+    set_design("independent") |>
+    set_outcome_type("numeric")
+  spec$fitted <- list(engine = "anova_oneway_welch")
+  out <- effects(spec, conf_level = 0.90)
+  expect_equal(out$fitted$es_metric, "Omega2")
+  expect_type(out$fitted$es_value, "double")
+})
+
+test_that("effects() computes epsilon squared for kruskal_wallis engine", {
+  df <- tibble::tibble(
+    outcome = c(1, 2, 3, 4, 5, 6, 7, 8, 9),
+    group = factor(rep(c("A", "B", "C"), each = 3))
+  )
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group) |>
+    set_design("independent") |>
+    set_outcome_type("numeric")
+  spec$fitted <- list(engine = "kruskal_wallis")
+  out <- effects(spec, conf_level = 0.90)
+  expect_equal(out$fitted$es_metric, "Epsilon2")
+  expect_type(out$fitted$es_value, "double")
+})
+
+test_that("effects() allows custom effect size functions", {
+  df <- tibble::tibble(
+    outcome = c(1, 2, 3, 4, 5, 6, 7, 8, 9),
+    group = factor(rep(c("A", "B", "C"), each = 3))
+  )
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group) |>
+    set_design("independent") |>
+    set_outcome_type("numeric")
+  spec$fitted <- list(engine = "anova_oneway_equal")
+  out <- effects(spec, effect = "omega_squared", conf_level = 0.90)
+  expect_equal(out$fitted$es_metric, "Omega2")
+  expect_type(out$fitted$es_value, "double")
+})
+
 # Unknown engines fallback to Hedges' g with a warning ----
 test_that("effects() defaults to Hedges g for unknown engine (with warning)", {
   fit <- comp_spec(mtcars) |>


### PR DESCRIPTION
## Summary
- expand `effects()` to support multi-group comparisons with default effect sizes for ANOVA and Kruskal-Wallis engines
- allow any `effectsize` metric to be requested and map sensible defaults per engine
- add helper to standardize multi-group numeric data
- add unit tests for new effect size handling and custom metrics

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_689d9cb867548325ab81ac5a59e85b74