### PR TITLE
Handle dynamic Within component in repeated ANOVA engine

### DIFF
--- a/R/engines.R
+++ b/R/engines.R
@@ -409,7 +409,16 @@ engine_anova_repeated <- function(data, meta) {
   mauchly <- meta$diagnostics$sphericity %||% diag_mauchly(df, outcome, group, id)
   fit <- stats::aov(outcome ~ group + Error(id / group), data = df)
   summ <- summary(fit)
-  within <- summ[["Error: Within"]][[1]]
+  nm <- names(summ)
+  idx <- grep("Within", nm)
+  if (!length(idx)) {
+    idx <- grep(":", nm)
+  }
+  if (!length(idx)) {
+    err_idx <- grep("^Error:", nm)
+    idx <- err_idx[length(err_idx)]
+  }
+  within <- summ[[idx]][[1]]
   tibble::tibble(
     test = "anova_repeated",
     method = "Repeated measures ANOVA",

--- a/tests/testthat/test-engines.R
+++ b/tests/testthat/test-engines.R
@@ -116,6 +116,25 @@ test_that("anova_repeated engine matches stats::aov", {
   expect_equal(res$p.value, unname(within["group","Pr(>F)"]))
 })
 
+test_that("anova_repeated works with non-standard group column names", {
+  df <- tibble::tibble(
+    id = rep(1:4, each = 3),
+    wave = factor(rep(c("A", "B", "C"), times = 4)),
+    outcome = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+  )
+  meta <- list(
+    roles = list(outcome = "outcome", group = "wave", id = "id"),
+    diagnostics = list(notes = character()),
+    settings = list()
+  )
+  res <- tidycomp:::engine_anova_repeated(df, meta)
+  expect_true(all(c("statistic", "df1", "df2", "p.value") %in% names(res)))
+  expect_false(is.na(res$statistic))
+  expect_false(is.na(res$df1))
+  expect_false(is.na(res$df2))
+  expect_false(is.na(res$p.value))
+})
+
 # Friedman --------------------------------------------------------------------
 
 test_that("friedman engine matches stats::friedman.test", {


### PR DESCRIPTION
## Summary
- Make `engine_anova_repeated()` robust to varying summary names when retrieving the within-subject component.
- Always populate F statistic, degrees of freedom, and p-value columns even if values are `NA`.
- Add a unit test ensuring repeated ANOVA works when the group column is named differently.

## Testing
- `R -q -e 'devtools::test()'` *(fails: there is no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_e_689ddd715ab88325a55c495a95ffc187