### PR TITLE
Fix repeated ANOVA summary indexing

### DIFF
--- a/R/engines.R
+++ b/R/engines.R
@@ -410,9 +410,9 @@ engine_anova_repeated <- function(data, meta) {
   fit <- stats::aov(outcome ~ group + Error(id / group), data = df)
   summ <- summary(fit)
   nm <- names(summ)
-  idx <- grep("Within", nm)
+  idx <- tail(grep("Within", nm), 1)
   if (!length(idx)) {
-    idx <- grep(":", nm)
+    idx <- tail(grep(":", nm), 1)
   }
   if (!length(idx)) {
     err_idx <- grep("^Error:", nm)


### PR DESCRIPTION
## Summary
- avoid subscript out-of-bounds in repeated-measures ANOVA engine by selecting only the final matching summary component

## Testing
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_689de29041a48325aa22368c33d9abfe