### PR TITLE
Handle paired effect sizes

### DIFF
--- a/R/effects.R
+++ b/R/effects.R
@@ -489,15 +489,32 @@ effects <- function(
 
     dat <- .get_spec_data(parent_spec)
     roles <- .get_spec_roles(parent_spec)
-    fml <- stats::as.formula(paste(roles$outcome, "~", roles$group))
 
-    d <- effectsize::cohens_d(
-      fml,
-      data = dat,
-      ci = ci,
-      hedges.correction = identical(type, "g"),
-      paired = !is.null(roles$id)
-    )
+    if (!is.null(roles$id)) {
+      df <- .standardize_paired_numeric(
+        dat,
+        roles$outcome,
+        roles$group,
+        roles$id
+      )
+      g <- names(df)
+      d <- effectsize::cohens_d(
+        df[[g[2]]],
+        df[[g[1]]],
+        ci = ci,
+        hedges.correction = identical(type, "g"),
+        paired = TRUE
+      )
+    } else {
+      fml <- stats::as.formula(paste(roles$outcome, "~", roles$group))
+      d <- effectsize::cohens_d(
+        fml,
+        data = dat,
+        ci = ci,
+        hedges.correction = identical(type, "g"),
+        paired = FALSE
+      )
+    }
 
     est <- if ("Hedges_g" %in% names(d)) d$Hedges_g else d$Cohens_d
     return(tibble::tibble(
@@ -527,14 +544,30 @@ effects <- function(
 
     dat <- .get_spec_data(parent_spec)
     roles <- .get_spec_roles(parent_spec)
-    fml <- stats::as.formula(paste(roles$outcome, "~", roles$group))
 
-    rbs <- effectsize::rank_biserial(
-      fml,
-      data = dat,
-      ci = ci,
-      paired = !is.null(roles$id)
-    )
+    if (!is.null(roles$id)) {
+      df <- .standardize_paired_numeric(
+        dat,
+        roles$outcome,
+        roles$group,
+        roles$id
+      )
+      g <- names(df)
+      rbs <- effectsize::rank_biserial(
+        df[[g[2]]],
+        df[[g[1]]],
+        ci = ci,
+        paired = TRUE
+      )
+    } else {
+      fml <- stats::as.formula(paste(roles$outcome, "~", roles$group))
+      rbs <- effectsize::rank_biserial(
+        fml,
+        data = dat,
+        ci = ci,
+        paired = FALSE
+      )
+    }
 
     return(tibble::tibble(
       effect = roles$group,

--- a/tests/testthat/test-effects.R
+++ b/tests/testthat/test-effects.R
@@ -108,3 +108,55 @@ test_that("effects() locates model for repeated measures", {
   expect_s3_class(es, "tbl_df")
   expect_false(is.null(attr(es, "model")))
 })
+
+# Cohen's d for paired designs
+test_that("effects() computes Cohen's d for paired design", {
+  skip_if_not_installed("effectsize")
+
+  df <- tibble::tibble(
+    id = rep(1:5, each = 2),
+    group = factor(rep(c("A", "B"), times = 5)),
+    outcome = c(3, 4, 4, 6, 5, 9, 6, 7, 7, 10)
+  )
+
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("paired") |>
+    set_outcome_type("numeric") |>
+    set_engine("paired_t") |>
+    test() |>
+    effects()
+
+  wide <- tidycomp:::.standardize_paired_numeric(df, "outcome", "group", "id")
+  g <- names(wide)
+  expected <- effectsize::cohens_d(wide[[g[2]]], wide[[g[1]]], paired = TRUE)
+
+  expect_s3_class(spec$effects, "tbl_df")
+  expect_equal(spec$effects$estimate, expected$Cohens_d)
+})
+
+# Rank-biserial for paired Wilcoxon tests
+test_that("effects() computes rank-biserial for paired design", {
+  skip_if_not_installed("effectsize")
+
+  df <- tibble::tibble(
+    id = rep(1:5, each = 2),
+    group = factor(rep(c("A", "B"), times = 5)),
+    outcome = c(3, 4, 4, 6, 5, 9, 6, 7, 7, 10)
+  )
+
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("paired") |>
+    set_outcome_type("numeric") |>
+    set_engine("wilcoxon_signed_rank") |>
+    test() |>
+    effects()
+
+  wide <- tidycomp:::.standardize_paired_numeric(df, "outcome", "group", "id")
+  g <- names(wide)
+  expected <- effectsize::rank_biserial(wide[[g[2]]], wide[[g[1]]], paired = TRUE)
+
+  expect_s3_class(spec$effects, "tbl_df")
+  expect_equal(spec$effects$estimate, expected$Rank_biserial)
+})


### PR DESCRIPTION
## Summary
- Standardize paired data before computing Cohen's d/g for t-tests
- Use vector-based inputs for paired rank-biserial calculations
- Add regression tests for paired Cohen's d and rank-biserial workflows

## Testing
- `R -q -e "testthat::test_local('.', reporter='summary')"` *(fails: Names of spec don't match; spec$diagnostics$sphericity not S3 object; anova_repeated sphericity correction; unused argument conf_level; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e70e431e88325878e3421c8578ebe