### PR TITLE
Fix effect size extraction for rank-biserial and Kendall's W

### DIFF
--- a/R/effects.R
+++ b/R/effects.R
@@ -572,7 +572,7 @@ effects <- function(
     return(tibble::tibble(
       effect = roles$group,
       type = "rank_biserial",
-      estimate = rbs$Rank_biserial,
+      estimate = rbs$r_rank_biserial %||% rbs$Rank_biserial %||% rbs[[1]],
       conf.low = if (!is.null(ci)) rbs$CI_low else NA_real_,
       conf.high = if (!is.null(ci)) rbs$CI_high else NA_real_
     ))
@@ -619,7 +619,7 @@ effects <- function(
     return(tibble::tibble(
       effect = roles$group,
       type = "kendalls_w",
-      estimate = kw$W,
+      estimate = kw$Kendalls_W %||% kw$W %||% kw[[1]],
       conf.low = if (!is.null(ci)) kw$CI_low else NA_real_,
       conf.high = if (!is.null(ci)) kw$CI_high else NA_real_
     ))

--- a/tests/testthat/test-effects.R
+++ b/tests/testthat/test-effects.R
@@ -158,5 +158,30 @@ test_that("effects() computes rank-biserial for paired design", {
   expected <- effectsize::rank_biserial(wide[[g[2]]], wide[[g[1]]], paired = TRUE)
 
   expect_s3_class(spec$effects, "tbl_df")
-  expect_equal(spec$effects$estimate, expected$Rank_biserial)
+  expect_equal(spec$effects$estimate, expected[[1]])
+})
+
+# Kendall's W for Friedman tests
+test_that("effects() computes Kendall's W for Friedman design", {
+  skip_if_not_installed("effectsize")
+
+  set.seed(1)
+  df <- tibble::tibble(
+    id = rep(1:5, each = 3),
+    group = factor(rep(c("A", "B", "C"), times = 5)),
+    outcome = rnorm(15)
+  )
+
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("repeated") |>
+    set_outcome_type("numeric") |>
+    set_engine("friedman") |>
+    test() |>
+    effects()
+
+  expected <- effectsize::kendalls_w(outcome ~ group | id, data = df)
+
+  expect_s3_class(spec$effects, "tbl_df")
+  expect_equal(spec$effects$estimate, expected[[1]])
 })


### PR DESCRIPTION
## Summary
- Handle renamed columns from `effectsize` for Wilcoxon/Mann–Whitney effect sizes
- Handle renamed columns from `effectsize` for Kendall's W
- Update and extend tests for rank-biserial and Friedman effect sizes

## Testing
- `R --vanilla -q <<'EOF'
if (!requireNamespace("testthat", quietly=TRUE)) install.packages("testthat", repos='https://cloud.r-project.org')
if (!requireNamespace("pkgload", quietly=TRUE)) install.packages("pkgload", repos='https://cloud.r-project.org')
if (!requireNamespace("tibble", quietly=TRUE)) install.packages("tibble", repos='https://cloud.r-project.org')
if (!requireNamespace("rlang", quietly=TRUE)) install.packages("rlang", repos='https://cloud.r-project.org')
if (!requireNamespace("cli", quietly=TRUE)) install.packages("cli", repos='https://cloud.r-project.org')
if (!requireNamespace("dplyr", quietly=TRUE)) install.packages("dplyr", repos='https://cloud.r-project.org')
if (!requireNamespace("purrr", quietly=TRUE)) install.packages("purrr", repos='https://cloud.r-project.org')
if (!requireNamespace("effectsize", quietly=TRUE)) install.packages("effectsize", repos='https://cloud.r-project.org')
if (!requireNamespace("performance", quietly=TRUE)) install.packages("performance", repos='https://cloud.r-project.org')
if (!requireNamespace("tidyr", quietly=TRUE)) install.packages("tidyr", repos='https://cloud.r-project.org')
if (!requireNamespace("rstatix", quietly=TRUE)) install.packages("rstatix", repos='https://cloud.r-project.org')
setwd("/workspace/tidycomp")
print("running test_local")
res <- testthat::test_local()
print(res)
EOF`
- Encountered failures in broader test suite (e.g., `spec$diagnostics$sphericity is not an S3 object` and `unused argument (conf_level = 0.9)`)


------
https://chatgpt.com/codex/tasks/task_e_689ecb72d22483259c88816067056d90