### PR TITLE
Respect sphericity diagnostics in repeated ANOVA engine

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -156,7 +156,11 @@ test <- function(spec) {
 
   res <- eng_fun(
     data = data,
-    meta = list(roles = spec$roles, diagnostics = spec$diagnostics)
+    meta = list(
+      roles = spec$roles,
+      diagnostics = spec$diagnostics,
+      engine = list(args = spec$engine_args %||% list())
+    )
   )
   class(res) <- c("comp_result", class(res))
   attr(res, "engine_hint") <- spec$effects_hint

--- a/tests/testthat/test-engines.R
+++ b/tests/testthat/test-engines.R
@@ -158,7 +158,6 @@ test_that("anova_repeated: uses uncorrected when sphericity OK; corrected when v
     set_design("repeated") |>
     set_outcome_type("numeric") |>
     set_engine("anova_repeated") |>
-    set_engine_options(correction = "auto", return_df = "auto") |>
     diagnose() |>
     test()
 
@@ -186,14 +185,24 @@ test_that("anova_repeated: uses uncorrected when sphericity OK; corrected when v
     set_design("repeated") |>
     set_outcome_type("numeric") |>
     set_engine("anova_repeated") |>
-    set_engine_options(correction = "GG", return_df = "corrected") |>
     diagnose() |>
     test()
 
   p_bad <- as.numeric(spec_bad$diagnostics$sphericity$p)[1]
   expect_true(is.finite(p_bad))
   expect_lt(p_bad, 0.05)
-  expect_true(spec_bad$fitted$metric[1] %in% c("GG", "HF"))
+  expect_identical(spec_bad$fitted$metric[1], "GG")
+
+  # Respect user preference for HF when provided
+  spec_bad_hf <- comp_spec(df_bad) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("repeated") |>
+    set_outcome_type("numeric") |>
+    set_engine("anova_repeated") |>
+    set_engine_options(correction = c("auto", "HF")) |>
+    diagnose() |>
+    test()
+  expect_identical(spec_bad_hf$fitted$metric[1], "HF")
 })
 
 test_that("anova_repeated works with non-standard group column names", {


### PR DESCRIPTION
## Summary
- honor precomputed sphericity diagnostics when choosing corrections
- pass engine options to engines, allowing GG/HF preferences
- add regression tests for automatic GG selection and HF preference

## Testing
- `R -q -e 'devtools::test()'` *(fails: package 'devtools' not installed)*
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: package 'testthat' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689f147b5a6083258f9a2680102edd67