### PR TITLE
Refactor sphericity diagnostics

### DIFF
--- a/R/engines.R
+++ b/R/engines.R
@@ -557,21 +557,10 @@ engine_anova_repeated <- function(data, meta) {
 
   # Sphericity check: prefer diagnostics supplied in `meta`; otherwise compute
   sp <- meta$diagnostics$sphericity
-  p_mauchly <- meta$diagnostics$sphericity_p %||% NA_real_
   if (is.null(sp)) {
     sp <- tryCatch(performance::check_sphericity(fit), error = function(e) NULL)
   }
-  if (is.na(p_mauchly) || !is.finite(p_mauchly)) {
-    p_mauchly <- tryCatch(
-      {
-        as.numeric(tibble::as_tibble(sp)$p[
-          tibble::as_tibble(sp)$Effect %in%
-            c("group", "group (within)", "within: group")
-        ][1])
-      },
-      error = function(e) NA_real_
-    )
-  }
+  p_mauchly <- .extract_sphericity_p(sp)
 
   # Epsilons available in afex table
   eps_GG <- if ("GG eps" %in% colnames(tab)) {
@@ -707,7 +696,7 @@ engine_anova_repeated <- function(data, meta) {
   }
 
   attr(res, "model") <- fit
-  attr(res, "diagnostics") <- list(sphericity = sp_df, sphericity_p = p_mauchly)
+  attr(res, "diagnostics") <- list(sphericity = sp_df)
   res
 }
 

--- a/R/test.R
+++ b/R/test.R
@@ -96,10 +96,13 @@ test <- function(spec) {
         "anova_repeated"
       )
       diag <- spec$diagnostics
-      if (!is.null(diag) && is.finite(diag$sphericity_p) && !is.na(diag$sphericity_p) && diag$sphericity_p < 0.05) {
-        cli::cli_warn(
-          "Sphericity violation detected; consider `set_engine('friedman')`."
-        )
+      if (!is.null(diag)) {
+        p_mauchly <- .extract_sphericity_p(diag$sphericity)
+        if (is.finite(p_mauchly) && !is.na(p_mauchly) && p_mauchly < 0.05) {
+          cli::cli_warn(
+            "Sphericity violation detected; consider `set_engine('friedman')`."
+          )
+        }
       }
     } else {
       if (g_levels > 2) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -235,6 +235,22 @@
   an["g", "Pr(>F)"]
 }
 
+#' Extract Mauchly p-value from sphericity results
+#'
+#' Given a sphericity table, return the first Mauchly p-value for standard
+#' within-subject effect names. If unavailable, returns `NA`.
+#'
+#' @param sp A data frame or tibble with columns `Effect` and `p`.
+#' @return Numeric scalar p-value or `NA_real_`.
+#' @keywords internal
+#' @noRd
+.extract_sphericity_p <- function(sp) {
+  tryCatch({
+    sp <- tibble::as_tibble(sp)
+    as.numeric(sp$p[sp$Effect %in% c("group", "group (within)", "within: group")][1])
+  }, error = function(e) NA_real_)
+}
+
 #' Check if the `effectsize` package is installed
 #'
 #' This internal helper is used to determine whether the \pkg{effectsize}

--- a/tests/testthat/test-diagnose.R
+++ b/tests/testthat/test-diagnose.R
@@ -9,7 +9,7 @@ test_that("diagnose attaches diagnostics with expected structure", {
 
   expect_named(
     spec$diagnostics,
-    c("group_sizes", "normality", "var_bf_p", "sphericity", "sphericity_p", "notes")
+    c("group_sizes", "normality", "var_bf_p", "sphericity", "notes")
   )
   expect_s3_class(spec$diagnostics$group_sizes, "tbl_df")
   expect_s3_class(spec$diagnostics$normality, "tbl_df")
@@ -85,6 +85,6 @@ test_that("diagnose computes sphericity p-value for repeated design", {
     set_design("repeated") |>
     set_outcome_type("numeric")
   spec <- diagnose(spec)
-  expect_true("sphericity_p" %in% names(spec$diagnostics))
   expect_s3_class(spec$diagnostics$sphericity, "tbl_df")
+  expect_true(is.numeric(spec$diagnostics$sphericity$p[1]))
 })

--- a/tests/testthat/test-test.R
+++ b/tests/testthat/test-test.R
@@ -163,9 +163,9 @@ test_that("nudge toward Mann-Whitney for small n and non-normal data", {
   spec$diagnostics <- list(
     group_sizes = tibble(n = c(10, 14)),
     normality = tibble(p_shapiro = c(0.001, 0.001)),
-    notes = character(),
     var_bf_p = NA,
-    sphericity_p = NA
+    sphericity = NULL,
+    notes = character()
   )
   expect_warning(suppressMessages(test(spec)), "mann_whitney")
 })
@@ -186,7 +186,7 @@ test_that("nudge toward Friedman when sphericity violated", {
     group_sizes = tibble(n = c(4, 4, 4)),
     normality = tibble(p_shapiro = c(0.5, 0.5, 0.5)),
     var_bf_p = NA,
-    sphericity_p = 0.01,
+    sphericity = tibble(Effect = "group", p = 0.01),
     notes = character()
   )
   expect_warning(suppressMessages(test(spec)), "friedman")


### PR DESCRIPTION
## Summary
- remove `sphericity_p` from diagnostics and rely on the `sphericity` tibble
- add helper to extract Mauchly p-value from sphericity results
- update engine selection, repeated-measures engine, and tests to use new helper

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_689f19ffe7848325acab620a37996a8c