### PR TITLE
Use sphericity diagnostics as repeated ANOVA fallback

### DIFF
--- a/R/diagnose.R
+++ b/R/diagnose.R
@@ -164,7 +164,6 @@ diagnose <- function(spec) {
     normality = norm,
     var_bf_p = p_bf,
     sphericity = sphericity,
-    sphericity_p = p_mauchly,
     notes = notes
   )
   cli::cli_inform("Diagnostics complete. {length(notes)} note{?s} recorded.")

--- a/R/test.R
+++ b/R/test.R
@@ -96,10 +96,18 @@ test <- function(spec) {
         "anova_repeated"
       )
       diag <- spec$diagnostics
-      if (!is.null(diag) && is.finite(diag$sphericity_p) && !is.na(diag$sphericity_p) && diag$sphericity_p < 0.05) {
-        cli::cli_warn(
-          "Sphericity violation detected; consider `set_engine('friedman')`."
+      if (!is.null(diag) && !is.null(diag$sphericity)) {
+        p_mauchly <- tryCatch(
+          as.numeric(diag$sphericity$p[
+            diag$sphericity$Effect %in% c("group", "group (within)", "within: group")
+          ][1]),
+          error = function(e) NA_real_
         )
+        if (is.finite(p_mauchly) && !is.na(p_mauchly) && p_mauchly < 0.05) {
+          cli::cli_warn(
+            "Sphericity violation detected; consider `set_engine('friedman')`."
+          )
+        }
       }
     } else {
       if (g_levels > 2) {

--- a/tests/testthat/test-diagnose.R
+++ b/tests/testthat/test-diagnose.R
@@ -9,7 +9,7 @@ test_that("diagnose attaches diagnostics with expected structure", {
 
   expect_named(
     spec$diagnostics,
-    c("group_sizes", "normality", "var_bf_p", "sphericity", "sphericity_p", "notes")
+    c("group_sizes", "normality", "var_bf_p", "sphericity", "notes")
   )
   expect_s3_class(spec$diagnostics$group_sizes, "tbl_df")
   expect_s3_class(spec$diagnostics$normality, "tbl_df")
@@ -85,6 +85,7 @@ test_that("diagnose computes sphericity p-value for repeated design", {
     set_design("repeated") |>
     set_outcome_type("numeric")
   spec <- diagnose(spec)
-  expect_true("sphericity_p" %in% names(spec$diagnostics))
+  expect_true("sphericity" %in% names(spec$diagnostics))
   expect_s3_class(spec$diagnostics$sphericity, "tbl_df")
+  expect_true("p" %in% names(spec$diagnostics$sphericity))
 })

--- a/tests/testthat/test-engines.R
+++ b/tests/testthat/test-engines.R
@@ -224,6 +224,23 @@ test_that("anova_repeated works with non-standard group column names", {
   expect_false(is.na(res$p.value))
 })
 
+test_that("anova_repeated uses sphericity diagnostics p when p-value missing", {
+  skip_if_not_installed("afex")
+  skip_if_not_installed("performance")
+
+  df <- tibble::tibble(
+    id = rep(1:4, each = 3),
+    group = factor(rep(c("A", "B", "C"), times = 4)),
+    outcome = rnorm(12)
+  )
+  meta <- make_meta()
+  meta$diagnostics$sphericity <- tibble::tibble(Effect = "group", p = 0.02)
+
+  res <- tidycomp:::engine_anova_repeated(df, meta)
+  diag <- attr(res, "diagnostics")
+  expect_equal(diag$sphericity$p[1], 0.02)
+})
+
 # Friedman --------------------------------------------------------------------
 
 test_that("friedman engine matches stats::friedman.test", {

--- a/tests/testthat/test-test.R
+++ b/tests/testthat/test-test.R
@@ -164,8 +164,7 @@ test_that("nudge toward Mann-Whitney for small n and non-normal data", {
     group_sizes = tibble(n = c(10, 14)),
     normality = tibble(p_shapiro = c(0.001, 0.001)),
     notes = character(),
-    var_bf_p = NA,
-    sphericity_p = NA
+    var_bf_p = NA
   )
   expect_warning(suppressMessages(test(spec)), "mann_whitney")
 })
@@ -186,7 +185,7 @@ test_that("nudge toward Friedman when sphericity violated", {
     group_sizes = tibble(n = c(4, 4, 4)),
     normality = tibble(p_shapiro = c(0.5, 0.5, 0.5)),
     var_bf_p = NA,
-    sphericity_p = 0.01,
+    sphericity = tibble(Effect = "group", p = 0.01),
     notes = character()
   )
   expect_warning(suppressMessages(test(spec)), "friedman")


### PR DESCRIPTION
## Summary
- Remove `sphericity_p` field from diagnostics and rely on `sphericity$p` for repeated-measures ANOVA
- Update diagnostics and `test()` warning logic to extract Mauchly p-value directly from the sphericity table
- Adjust regression tests to reflect new diagnostics structure

## Testing
- `R -q -e 'testthat::test_local()'` *(fails: command not found)*
- `apt-get install -y r-base r-cran-testthat` *(fails: requires ~937MB of packages, installation aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689f19fec08c83258b119134caa0f3c0