### PR TITLE
Respect sphericity diagnostics in repeated ANOVA

### DIFF
--- a/tests/testthat/test-diagnose.R
+++ b/tests/testthat/test-diagnose.R
@@ -75,6 +75,7 @@ test_that("diagnose errors with different non-numeric outcome types", {
 
 test_that("diagnose computes sphericity p-value for repeated design", {
   testthat::skip_if_not_installed("afex")
+  testthat::skip_if_not_installed("performance")
   df <- tibble::tibble(
     id = rep(1:4, each = 3),
     group = factor(rep(c("A", "B", "C"), times = 4)),


### PR DESCRIPTION
## Summary
- rely on provided sphericity diagnostics instead of recomputing
- honor user-specified correction preferences and warn when uncorrected is requested despite violation
- update tests for performance dependency and new behavior

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_689f286f4dc48325a2bcc2be798970a3