### PR TITLE
Handle sphericity automatically in repeated ANOVA

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tidycomp (development version)
 
+* `engine_anova_repeated` now computes sphericity internally when diagnostics
+  are absent and automatically applies Greenhouse-Geisser or Huynh-Feldt
+  corrections when violations are detected.
+
 # tidycomp 0.2.0
 
 * Added paired 2-group comparisons: `engine_paired_t` and `engine_wilcoxon_signed_rank`.

--- a/R/engines.R
+++ b/R/engines.R
@@ -555,6 +555,15 @@ engine_anova_repeated <- function(data, meta) {
   sp <- meta$diagnostics$sphericity
   p_mauchly <- .extract_sphericity_p(sp)
 
+  # If diagnostics missing, attempt to compute sphericity
+  if ((is.null(sp) || is.na(p_mauchly)) && rlang::is_installed("performance")) {
+    sp <- tryCatch(performance::check_sphericity(fit), error = function(e) NULL)
+    if (!is.null(sp)) {
+      sp <- tryCatch(tibble::as_tibble(sp), error = function(e) sp)
+      p_mauchly <- .extract_sphericity_p(sp)
+    }
+  }
+
   # Epsilons available in afex table
   eps_GG <- if ("GG eps" %in% colnames(tab)) {
     unname(tab["group", "GG eps"])


### PR DESCRIPTION
## Summary
- Compute Mauchly's test within `engine_anova_repeated` when diagnostics are absent and apply GG/HF corrections if needed
- Test automatic sphericity handling when `diagnose()` is skipped
- Note the new behavior in NEWS

## Testing
- `R -q -e 'devtools::test()'` *(fails: there is no package called ‘devtools’)*
- `R -q -e 'install.packages(c("devtools","afex","performance"), repos="https://cloud.r-project.org")'` *(fails: packages are not available for this version of R)*

------
https://chatgpt.com/codex/tasks/task_e_689f2f11591c8325824180bc39c34a7f