### PR TITLE
Refactor repeated ANOVA engine workflow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # tidycomp (development version)
 
-* `engine_anova_repeated` now computes sphericity internally when diagnostics
-  are absent and automatically applies Greenhouse-Geisser or Huynh-Feldt
-  corrections when violations are detected.
+* `engine_anova_repeated` now determines sphericity internally and selects an
+  appropriate correction (none, GG, or HF) before fitting a single
+  `afex::aov_ez()` model.
 
 # tidycomp 0.2.0
 

--- a/tests/testthat/test-engines.R
+++ b/tests/testthat/test-engines.R
@@ -193,6 +193,7 @@ test_that("anova_repeated: uses uncorrected when sphericity OK; corrected when v
   expect_true(is.finite(p_bad))
   expect_lt(p_bad, 0.05)
   expect_identical(spec_bad$fitted$metric[1], "GG")
+  expect_true(any(grepl("GG correction", spec_bad$fitted$notes[[1]])))
 
   # Respect user preference for HF when provided
   spec_bad_hf <- comp_spec(df_bad) |>
@@ -200,10 +201,11 @@ test_that("anova_repeated: uses uncorrected when sphericity OK; corrected when v
     set_design("repeated") |>
     set_outcome_type("numeric") |>
     set_engine("anova_repeated") |>
-    set_engine_options(correction = c("auto", "HF")) |>
+    set_engine_options(correction = "HF") |>
     diagnose() |>
     test()
   expect_identical(spec_bad_hf$fitted$metric[1], "HF")
+  expect_true(any(grepl("HF correction", spec_bad_hf$fitted$notes[[1]])))
 
   # Respect user request for uncorrected despite violation
   spec_bad_none <- comp_spec(df_bad) |>
@@ -215,7 +217,6 @@ test_that("anova_repeated: uses uncorrected when sphericity OK; corrected when v
     diagnose() |>
     test()
   expect_identical(spec_bad_none$fitted$metric[1], "uncorrected")
-  expect_true(any(grepl("Sphericity violated", spec_bad_none$fitted$notes[[1]])))
 })
 
 test_that("anova_repeated computes sphericity internally when diagnostics missing", {


### PR DESCRIPTION
## Summary
- Simplify `engine_anova_repeated` to determine sphericity, choose correction, and fit a single `aov_ez` model
- Adjust tests for new correction option handling and note reporting
- Document new repeated ANOVA workflow in NEWS

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_689f416bd5ec8325a620b4615ec8bff6