### PR TITLE
Handle numeric sphericity results

### DIFF
--- a/tests/testthat/test-extract-sphericity-p.R
+++ b/tests/testthat/test-extract-sphericity-p.R
@@ -1,0 +1,30 @@
+test_that(".extract_sphericity_p handles tibble input", {
+  sp <- tibble::tibble(Effect = c("group", "other"), p = c(0.02, 0.5))
+  res <- tidycomp:::.extract_sphericity_p(sp)
+  expect_type(res, "double")
+  expect_length(res, 1)
+  expect_equal(res, 0.02)
+})
+
+test_that(".extract_sphericity_p handles named numeric vector", {
+  sp <- c(group = 0.03, other = 0.5)
+  res <- tidycomp:::.extract_sphericity_p(sp)
+  expect_type(res, "double")
+  expect_length(res, 1)
+  expect_equal(res, 0.03)
+})
+
+test_that(".extract_sphericity_p handles unnamed numeric vector", {
+  sp <- c(0.04, 0.5)
+  res <- tidycomp:::.extract_sphericity_p(sp)
+  expect_type(res, "double")
+  expect_length(res, 1)
+  expect_identical(res, NA_real_)
+})
+
+test_that(".extract_sphericity_p handles NULL input", {
+  res <- tidycomp:::.extract_sphericity_p(NULL)
+  expect_type(res, "double")
+  expect_length(res, 1)
+  expect_identical(res, NA_real_)
+})


### PR DESCRIPTION
## Summary
- Make `.extract_sphericity_p()` robust to `NULL` and numeric vector inputs
- Add tests covering tibble, named numeric, unnamed numeric, and NULL sphericity results

## Testing
- `devtools::test()` *(fails: anova_repeated tests due to environment; new tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_689f4835c1e483258021efa98cc8aeaa