### PR TITLE
Add categorical group comparison engines

### DIFF
--- a/R/diagnose.R
+++ b/R/diagnose.R
@@ -1,44 +1,44 @@
 #' Diagnose a comparison specification (non-destructive)
 #'
-#' Run lightweight checks on a `comp_spec`: group sizes, variance
-#' heterogeneity (Brown–Forsythe proxy), within-group normality (Shapiro),
-#' and simple IQR-based outlier counts. The function **does not** alter
-#' the raw data; it attaches a `diagnostics` list to the spec.
+#' Run lightweight checks on a `comp_spec`: for numeric outcomes this includes
+#' group sizes, variance heterogeneity (Brown–Forsythe proxy), within-group
+#' normality (Shapiro), and simple IQR-based outlier counts. For binary
+#' outcomes, it inspects the contingency table between outcome and group to
+#' determine whether assumptions for chi-squared tests are met or if an exact
+#' test is warranted. The function **does not** alter the raw data; it attaches
+#' a `diagnostics` list to the spec.
 #'
 #' @param spec A `comp_spec` with roles/design/outcome type already set.
 #'   Must include at least an outcome variable and a group variable in
 #'   `spec$roles`.
 #'
 #' @details
-#' The following summaries are computed and stored in `spec$diagnostics`:
+#' For numeric outcomes, the following summaries are stored in
+#' `spec$diagnostics`:
 #'
 #' - `group_sizes`: a tibble with counts per group.
-#' - `var_bf_p`: Brown-Forsythe proxy p‑value for variance heterogeneity.
-#' - `normality`: per-group Shapiro-Wilk p‑values (flagged only; not enforced).
+#' - `var_bf_p`: Brown-Forsythe proxy p-value for variance heterogeneity.
+#' - `normality`: per-group Shapiro-Wilk p-values (flagged only; not enforced).
 #' - `sphericity`: Mauchly p-values for repeated-measures designs.
 #' - `notes`: human-readable notes highlighting potential issues
 #'   (e.g., small groups, variance heterogeneity, non-normality, outliers).
 #'
-#' These diagnostics are intended as **signals** to guide strategy/engine
-#' choices (e.g., robust/permutation) rather than hard pass/fail gates.
+#' For binary outcomes, the diagnostics include:
+#'
+#' - `table`: the observed contingency table.
+#' - `expected`: expected counts (when available).
+#' - `engine`: recommended engine based on cell counts.
+#' - `notes`: notes on small cells or other issues.
 #'
 #' @return The input `spec`, updated with a `diagnostics` list.
 #'
 #' @examples
-#' # setup
 #' spec <- comp_spec(mtcars)
-#' spec$roles <- list(outcome = "mpg", group = "cyl")
-#' spec$outcome_type <- "numeric"
-#'
-#' # run diagnostics (non-destructive; adds `diagnostics`)
+#' spec$roles <- list(outcome = "am", group = "cyl")
+#' spec$design <- "independent"
+#' spec$outcome_type <- "binary"
 #' spec <- diagnose(spec)
-#' spec$diagnostics$group_sizes
-#' spec$diagnostics$notes
-#'
-#' # Example interpretation:
-#' # - Consider robust/permutation strategies if variance heterogeneity or
-#' #   non-normality is flagged.
-#' # - Very small groups may limit parametric assumptions.
+#' spec$diagnostics$engine
 #' @export
 diagnose <- function(spec) {
   stopifnot(inherits(spec, "comp_spec"))
@@ -50,114 +50,121 @@ diagnose <- function(spec) {
   outcome <- roles$outcome
   group <- roles$group
 
-  if (!is.numeric(df[[outcome]])) {
-    cli::cli_abort("`diagnose()` currently supports numeric outcomes.")
-  }
-  if (!is.factor(df[[group]])) {
-    df[[group]] <- factor(df[[group]])
-  }
-
-  g_n <- dplyr::count(df, .data[[group]], name = "n")
-  small_n <- any(g_n$n < 30)
-
-  # normality flags per group (only when n >= 3)
-  norm <- dplyr::group_by(df, .data[[group]]) |>
-    dplyr::summarise(
-      n = dplyr::n(),
-      p_shapiro = ifelse(
-        n >= 3,
-        tryCatch(
-          stats::shapiro.test(.data[[outcome]])$p.value,
-          error = function(e) NA_real_
+  if (spec$outcome_type == "numeric") {
+    if (!is.numeric(df[[outcome]])) {
+      cli::cli_abort("`diagnose()` currently supports numeric outcomes.")
+    }
+    if (!is.factor(df[[group]])) {
+      df[[group]] <- factor(df[[group]])
+    }
+    g_n <- dplyr::count(df, .data[[group]], name = "n")
+    small_n <- any(g_n$n < 30)
+    norm <- dplyr::group_by(df, .data[[group]]) |>
+      dplyr::summarise(
+        n = dplyr::n(),
+        p_shapiro = ifelse(
+          n >= 3,
+          tryCatch(
+            stats::shapiro.test(.data[[outcome]])$p.value,
+            error = function(e) NA_real_
+          ),
+          NA_real_
         ),
-        NA_real_
-      ),
-      .groups = "drop"
-    )
-
-  # variance heterogeneity (Brown-Forsythe proxy)
-  p_bf <- .brown_forsythe(df[[outcome]], df[[group]])
-  var_hetero <- is.finite(p_bf) && !is.na(p_bf) && p_bf < 0.05
-
-  # outliers (IQR rule), per group
-  out_counts <- dplyr::group_by(df, .data[[group]]) |>
-    dplyr::summarise(
-      n = dplyr::n(),
-      out_lo = {
-        lim <- .flag_outliers(.data[[outcome]], method = "iqr")
-        sum(.data[[outcome]] < lim$lo, na.rm = TRUE)
-      },
-      out_hi = {
-        lim <- .flag_outliers(.data[[outcome]], method = "iqr")
-        sum(.data[[outcome]] > lim$hi, na.rm = TRUE)
-      },
-      .groups = "drop"
-    )
-  out_total <- sum(out_counts$out_lo + out_counts$out_hi)
-
-  notes <- c()
-  if (small_n) {
-    notes <- c(
-      notes,
-      "Small group sizes (< 30): CLT less reliable; prefer robust/Welch or permutation."
-    )
-  }
-  if (isTRUE(var_hetero)) {
-    notes <- c(notes, "Variance heterogeneity flagged (Brown-Forsythe proxy).")
-  }
-  if (any(norm$p_shapiro < 0.05, na.rm = TRUE)) {
-    notes <- c(
-      notes,
-      "Shapiro normality flagged in at least one group (interpret with caution)."
-    )
-  }
-  if (out_total > 0) {
-    notes <- c(
-      notes,
-      sprintf("Potential outliers detected (IQR*3): %d total.", out_total)
-    )
-  }
-
-  # sphericity check for repeated-measures design
-  sphericity <- NULL
-  if (identical(spec$design, "repeated") && !is.null(roles$id)) {
-    id <- roles$id
-    .validate_cols(df, id)
-    if (rlang::is_installed(c("afex", "performance"))) {
-      fit <- tryCatch(
-        afex::aov_ez(id = id, dv = outcome, within = group, data = df),
-        error = function(e) NULL
+        .groups = "drop"
       )
-      if (!is.null(fit)) {
-        sp <- tryCatch(performance::check_sphericity(fit), error = function(e) {
-          NULL
-        })
-        if (!is.null(sp)) {
-          if (is.data.frame(sp)) {
-            sphericity <- tibble::as_tibble(sp)
-          } else {
-            eff <- names(sp)
-            if (is.null(eff)) {
-              eff <- NA_character_
+    p_bf <- .brown_forsythe(df[[outcome]], df[[group]])
+    var_hetero <- is.finite(p_bf) && !is.na(p_bf) && p_bf < 0.05
+    out_counts <- dplyr::group_by(df, .data[[group]]) |>
+      dplyr::summarise(
+        n = dplyr::n(),
+        out_lo = {
+          lim <- .flag_outliers(.data[[outcome]], method = "iqr")
+          sum(.data[[outcome]] < lim$lo, na.rm = TRUE)
+        },
+        out_hi = {
+          lim <- .flag_outliers(.data[[outcome]], method = "iqr")
+          sum(.data[[outcome]] > lim$hi, na.rm = TRUE)
+        },
+        .groups = "drop"
+      )
+    out_total <- sum(out_counts$out_lo + out_counts$out_hi)
+    notes <- c()
+    if (small_n) {
+      notes <- c(
+        notes,
+        "Small group sizes (< 30): CLT less reliable; prefer robust/Welch or permutation."
+      )
+    }
+    if (isTRUE(var_hetero)) {
+      notes <- c(notes, "Variance heterogeneity flagged (Brown-Forsythe proxy).")
+    }
+    if (any(norm$p_shapiro < 0.05, na.rm = TRUE)) {
+      notes <- c(
+        notes,
+        "Shapiro normality flagged in at least one group (interpret with caution)."
+      )
+    }
+    if (out_total > 0) {
+      notes <- c(
+        notes,
+        sprintf("Potential outliers detected (IQR*3): %d total.", out_total)
+      )
+    }
+    sphericity <- NULL
+    if (identical(spec$design, "repeated") && !is.null(roles$id)) {
+      id <- roles$id
+      .validate_cols(df, id)
+      if (rlang::is_installed(c("afex", "performance"))) {
+        fit <- tryCatch(
+          afex::aov_ez(id = id, dv = outcome, within = group, data = df),
+          error = function(e) NULL
+        )
+        if (!is.null(fit)) {
+          sp <- tryCatch(performance::check_sphericity(fit), error = function(e) NULL)
+          if (!is.null(sp)) {
+            if (is.data.frame(sp)) {
+              sphericity <- tibble::as_tibble(sp)
+            } else {
+              eff <- names(sp)
+              if (is.null(eff)) {
+                eff <- NA_character_
+              }
+              sphericity <- tibble::tibble(Effect = eff, p = as.numeric(sp))
             }
-            sphericity <- tibble::tibble(Effect = eff, p = as.numeric(sp))
-          }
-          p_mauchly <- .extract_sphericity_p(sphericity)
-          if (!is.na(p_mauchly) && is.finite(p_mauchly) && p_mauchly < 0.05) {
-            notes <- c(notes, "Sphericity violation flagged (Mauchly p < .05).")
+            p_mauchly <- .extract_sphericity_p(sphericity)
+            if (!is.na(p_mauchly) && is.finite(p_mauchly) && p_mauchly < 0.05) {
+              notes <- c(notes, "Sphericity violation flagged (Mauchly p < .05).")
+            }
           }
         }
       }
     }
+    spec$diagnostics <- list(
+      group_sizes = g_n,
+      normality = norm,
+      var_bf_p = p_bf,
+      sphericity = sphericity,
+      notes = notes
+    )
+  } else if (spec$outcome_type == "binary") {
+    if (spec$design == "paired") {
+      diag <- .diagnose_paired_contingency(df, outcome, group, roles$id)
+    } else if (spec$design == "independent") {
+      if (!is.factor(df[[group]])) {
+        df[[group]] <- factor(df[[group]])
+      }
+      if (!is.factor(df[[outcome]])) {
+        df[[outcome]] <- factor(df[[outcome]])
+      }
+      diag <- .diagnose_contingency(df[[group]], df[[outcome]])
+    } else {
+      cli::cli_abort("`diagnose()` supports binary outcomes for independent or paired designs.")
+    }
+    spec$diagnostics <- diag
+  } else {
+    cli::cli_abort("`diagnose()` does not support outcome type '{spec$outcome_type}'.")
   }
-
-  spec$diagnostics <- list(
-    group_sizes = g_n,
-    normality = norm,
-    var_bf_p = p_bf,
-    sphericity = sphericity,
-    notes = notes
-  )
+  notes <- spec$diagnostics$notes %||% character()
   cli::cli_inform("Diagnostics complete. {length(notes)} note{?s} recorded.")
   spec
 }

--- a/R/test.R
+++ b/R/test.R
@@ -6,12 +6,12 @@
 #'
 #' @param spec A `comp_spec` created by [comp_spec()] with roles set via
 #'   `set_roles(outcome, group)`, `design = "independent"` or `"paired"`, and
-#'   `outcome_type = "numeric"`. Optionally, run [diagnose()] beforehand.
+#'   `outcome_type = "numeric"` or `"binary"`. Optionally, run [diagnose()] beforehand.
 #'
 #' @details
 #' **Scope (MVP):**
 #' - Design: `design = "independent"` or `"paired"`.
-#' - Outcome: `outcome_type = "numeric"` only.
+#' - Outcome: `outcome_type = "numeric"` or `"binary"`.
 #'
 #' **Engine selection (defaults if `spec$engine` is `NULL`):**
 #' - `strategy = "parametric"` → Student's *t* (`"student_t"`).
@@ -65,91 +65,110 @@ test <- function(spec) {
       "Paired or repeated designs require an id role via `set_roles(id = ...)`."
     )
   }
-  if (is.null(spec$outcome_type) || spec$outcome_type != "numeric") {
-    cli::cli_abort("MVP `test()` supports `outcome_type = 'numeric'` only.")
+  if (is.null(spec$outcome_type) || !spec$outcome_type %in% c("numeric", "binary")) {
+    cli::cli_abort("MVP `test()` supports `outcome_type = 'numeric'` or 'binary'.")
   }
 
   data <- spec$data_prepared %||% spec$data_raw
-  if (is.null(spec$diagnostics)) {
+  if (spec$outcome_type == "binary") {
+    diag <- spec$diagnostics
+    if (is.null(diag)) {
+      cli::cli_warn("`diagnose()` not run; running contingency checks.")
+      if (spec$design == "paired") {
+        diag <- .diagnose_paired_contingency(data, spec$roles$outcome, spec$roles$group, spec$roles$id)
+      } else {
+        g <- data[[spec$roles$group]]
+        o <- data[[spec$roles$outcome]]
+        if (!is.factor(g)) g <- factor(g)
+        if (!is.factor(o)) o <- factor(o)
+        diag <- .diagnose_contingency(g, o)
+      }
+      spec$diagnostics <- diag
+    }
+  } else if (is.null(spec$diagnostics)) {
     cli::cli_warn("`diagnose()` not run; proceeding without diagnostic notes.")
   }
 
   # engine choice
   engine <- spec$engine
   if (is.null(engine)) {
-    g_levels <- if (!is.null(spec$roles$group)) {
-      nlevels(factor(data[[spec$roles$group]]))
+    if (spec$outcome_type == "binary") {
+      engine <- spec$diagnostics$engine
     } else {
-      0 # nocov
-    }
-    if (spec$design == "paired") {
-      engine <- switch(
-        spec$strategy,
-        auto = "paired_t",
-        pragmatic = "paired_t",
-        parametric = "paired_t",
-        robust = "paired_t",
-        permutation = "paired_t",
-        "paired_t"
-      )
-    } else if (spec$design == "repeated") {
-      engine <- switch(
-        spec$strategy,
-        auto = "anova_repeated",
-        pragmatic = "anova_repeated",
-        parametric = "anova_repeated",
-        robust = "anova_repeated",
-        permutation = "anova_repeated",
-        "anova_repeated"
-      )
-      diag <- spec$diagnostics
-      if (!is.null(diag)) {
-        p_mauchly <- .extract_sphericity_p(diag$sphericity)
-        if (is.finite(p_mauchly) && !is.na(p_mauchly) && p_mauchly < 0.05) {
-          cli::cli_warn(
-            "Sphericity violation detected; consider `set_engine('friedman')`."
-          )
-        }
+      g_levels <- if (!is.null(spec$roles$group)) {
+        nlevels(factor(data[[spec$roles$group]]))
+      } else {
+        0 # nocov
       }
-    } else {
-      if (g_levels > 2) {
+      if (spec$design == "paired") {
         engine <- switch(
           spec$strategy,
-          auto = "anova_oneway_welch",
-          pragmatic = "anova_oneway_welch",
-          parametric = "anova_oneway_equal",
-          robust = "anova_oneway_welch",
-          permutation = "anova_oneway_welch",
-          "anova_oneway_welch"
+          auto = "paired_t",
+          pragmatic = "paired_t",
+          parametric = "paired_t",
+          robust = "paired_t",
+          permutation = "paired_t",
+          "paired_t"
+        )
+      } else if (spec$design == "repeated") {
+        engine <- switch(
+          spec$strategy,
+          auto = "anova_repeated",
+          pragmatic = "anova_repeated",
+          parametric = "anova_repeated",
+          robust = "anova_repeated",
+          permutation = "anova_repeated",
+          "anova_repeated"
         )
         diag <- spec$diagnostics
         if (!is.null(diag)) {
-          small_n <- any((diag$group_sizes$n) < 15)
-          nonnorm <- any(diag$normality$p_shapiro < 0.01, na.rm = TRUE)
-          if (small_n && nonnorm) {
+          p_mauchly <- .extract_sphericity_p(diag$sphericity)
+          if (is.finite(p_mauchly) && !is.na(p_mauchly) && p_mauchly < 0.05) {
             cli::cli_warn(
-              "Severe non-normality with very small n detected; consider `set_engine('kruskal_wallis')`."
+              "Sphericity violation detected; consider `set_engine('friedman')`."
             )
           }
         }
       } else {
-        engine <- switch(
-          spec$strategy,
-          auto = "welch_t",
-          pragmatic = "welch_t",
-          parametric = "student_t",
-          robust = "welch_t",
-          permutation = "welch_t",
-          "welch_t"
-        )
-        diag <- spec$diagnostics
-        if (!is.null(diag)) {
-          small_n <- any((diag$group_sizes$n) < 15)
-          nonnorm <- any(diag$normality$p_shapiro < 0.01, na.rm = TRUE)
-          if (small_n && nonnorm) {
-            cli::cli_warn(
-              "Severe non-normality with very small n detected; consider `set_engine('mann_whitney')`."
-            )
+        if (g_levels > 2) {
+          engine <- switch(
+            spec$strategy,
+            auto = "anova_oneway_welch",
+            pragmatic = "anova_oneway_welch",
+            parametric = "anova_oneway_equal",
+            robust = "anova_oneway_welch",
+            permutation = "anova_oneway_welch",
+            "anova_oneway_welch"
+          )
+          diag <- spec$diagnostics
+          if (!is.null(diag)) {
+            small_n <- any((diag$group_sizes$n) < 15)
+            nonnorm <- any(diag$normality$p_shapiro < 0.01, na.rm = TRUE)
+            if (small_n && nonnorm) {
+              cli::cli_warn(
+                "Severe non-normality with very small n detected; consider `set_engine('kruskal_wallis')`."
+              )
+            }
+          }
+        } else {
+          engine <- switch(
+            spec$strategy,
+            auto = "welch_t",
+            pragmatic = "welch_t",
+            parametric = "student_t",
+            robust = "welch_t",
+            permutation = "welch_t",
+            "welch_t"
+          )
+          diag <- spec$diagnostics
+          if (!is.null(diag)) {
+            small_n <- any((diag$group_sizes$n) < 15)
+            nonnorm <- any(diag$normality$p_shapiro < 0.01, na.rm = TRUE)
+            if (small_n && nonnorm) {
+              cli::cli_warn(
+                "Severe non-normality with very small n detected; consider `set_engine('mann_whitney')`."
+              )
+            }
           }
         }
       }

--- a/man/diagnose.Rd
+++ b/man/diagnose.Rd
@@ -15,20 +15,29 @@ Must include at least an outcome variable and a group variable in
 The input \code{spec}, updated with a \code{diagnostics} list.
 }
 \description{
-Run lightweight checks on a \code{comp_spec}: group sizes, variance
-heterogeneity (Brown–Forsythe proxy), within-group normality (Shapiro),
-and simple IQR-based outlier counts. The function \strong{does not} alter
-the raw data; it attaches a \code{diagnostics} list to the spec.
+Run lightweight checks on a \code{comp_spec}. For numeric outcomes this includes
+group sizes, variance heterogeneity (Brown--Forsythe proxy), within-group normality (Shapiro),
+and simple IQR-based outlier counts. For binary outcomes it inspects the contingency
+table between outcome and group to determine whether chi-squared assumptions hold
+or if an exact test is recommended. The function \strong{does not} alter the raw data; it attaches a \code{diagnostics} list to the spec.
 }
 \details{
-The following summaries are computed and stored in \code{spec$diagnostics}:
+For numeric outcomes, the following summaries are stored in \code{spec$diagnostics}:
 \itemize{
 \item \code{group_sizes}: a tibble with counts per group.
-\item \code{var_bf_p}: Brown-Forsythe proxy p‑value for variance heterogeneity.
-\item \code{normality}: per-group Shapiro-Wilk p‑values (flagged only; not enforced).
+\item \code{var_bf_p}: Brown-Forsythe proxy p-value for variance heterogeneity.
+\item \code{normality}: per-group Shapiro-Wilk p-values (flagged only; not enforced).
 \item \code{sphericity}: Mauchly p-values for repeated-measures designs.
 \item \code{notes}: human-readable notes highlighting potential issues
 (e.g., small groups, variance heterogeneity, non-normality, outliers).
+}
+
+For binary outcomes, diagnostics include:
+\itemize{
+\item \code{table}: the observed contingency table.
+\item \code{expected}: expected counts (when available).
+\item \code{engine}: recommended engine based on cell counts.
+\item \code{notes}: notes on small cells or other issues.
 }
 
 These diagnostics are intended as \strong{signals} to guide strategy/engine
@@ -37,16 +46,9 @@ choices (e.g., robust/permutation) rather than hard pass/fail gates.
 \examples{
 # setup
 spec <- comp_spec(mtcars)
-spec$roles <- list(outcome = "mpg", group = "cyl")
-spec$outcome_type <- "numeric"
-
-# run diagnostics (non-destructive; adds `diagnostics`)
+spec$roles <- list(outcome = "am", group = "cyl")
+spec$design <- "independent"
+spec$outcome_type <- "binary"
 spec <- diagnose(spec)
-spec$diagnostics$group_sizes
-spec$diagnostics$notes
-
-# Example interpretation:
-# - Consider robust/permutation strategies if variance heterogeneity or
-#   non-normality is flagged.
-# - Very small groups may limit parametric assumptions.
+spec$diagnostics$engine
 }

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -9,7 +9,7 @@ test(spec)
 \arguments{
 \item{spec}{A \code{comp_spec} created by \code{\link[=comp_spec]{comp_spec()}} with roles set via
 \code{set_roles(outcome, group)}, \code{design = "independent"} or \code{"paired"}, and
-\code{outcome_type = "numeric"}. Optionally, run \code{\link[=diagnose]{diagnose()}} beforehand.}
+\code{outcome_type = "numeric"} or \code{"binary"}. Optionally, run \code{\link[=diagnose]{diagnose()}} beforehand.}
 }
 \value{
 The input \code{spec}, updated with a fitted \code{comp_result} in \code{spec$fitted}.
@@ -23,7 +23,7 @@ and, when available, \code{spec$diagnostics}.
 \strong{Scope (MVP):}
 \itemize{
 \item Design: \code{design = "independent"} or \code{"paired"}.
-\item Outcome: \code{outcome_type = "numeric"} only.
+\item Outcome: \code{outcome_type = "numeric"} or \code{"binary"}.
 }
 
 \strong{Engine selection (defaults if \code{spec$engine} is \code{NULL}):}

--- a/tests/testthat/test-diagnose.R
+++ b/tests/testthat/test-diagnose.R
@@ -17,6 +17,20 @@ test_that("diagnose attaches diagnostics with expected structure", {
   expect_type(spec$diagnostics$notes, "character")
 })
 
+test_that("diagnose reports contingency info for binary outcomes", {
+  df <- tibble::tibble(
+    outcome = factor(c("yes", "no", "yes", "no")),
+    group = factor(c("A", "A", "B", "B"))
+  )
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group) |>
+    set_design("independent") |>
+    set_outcome_type("binary")
+  spec <- diagnose(spec)
+  expect_named(spec$diagnostics, c("table", "expected", "engine", "notes"))
+  expect_equal(spec$diagnostics$engine, "fisher_exact")
+})
+
 test_that("diagnose errors when outcome is not numeric", {
   # Create a spec with non-numeric outcome
   df <- tibble::tibble(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -439,3 +439,49 @@ test_that(".standardize_multi_group_numeric aborts when group has <2 levels", {
     "Group must have at least 2 levels"
   )
 })
+
+# -----------------------------------------------------------------------------
+# Factor standardization helpers
+# -----------------------------------------------------------------------------
+
+test_that(".standardize_two_group_factor returns expected tibble", {
+  data <- data.frame(
+    outcome = c("yes", "no", "yes", "no"),
+    group = c("A", "A", "B", "B")
+  )
+  res <- tidycomp:::.standardize_two_group_factor(data, "outcome", "group")
+  expect_s3_class(res, "tbl_df")
+  expect_true(is.factor(res$outcome))
+  expect_true(is.factor(res$group))
+})
+
+test_that(".standardize_two_group_factor validates levels", {
+  data <- data.frame(outcome = c("a", "a", "a"), group = c("A", "B", "B"))
+  expect_error(
+    tidycomp:::.standardize_two_group_factor(data, "outcome", "group"),
+    "at least 2 levels"
+  )
+})
+
+test_that(".standardize_paired_categorical returns wide tibble", {
+  data <- tibble::tibble(
+    id = rep(1:3, each = 2),
+    group = factor(rep(c("A", "B"), times = 3)),
+    outcome = factor(c("yes", "no", "no", "no", "yes", "yes"))
+  )
+  res <- tidycomp:::.standardize_paired_categorical(data, "outcome", "group", "id")
+  expect_s3_class(res, "tbl_df")
+  expect_equal(ncol(res), 2)
+})
+
+test_that(".standardize_paired_categorical validates outcome levels", {
+  data <- tibble::tibble(
+    id = rep(1:2, each = 2),
+    group = factor(rep(c("A", "B"), times = 2)),
+    outcome = factor(c("yes", "yes", "no", "no"))
+  )
+  expect_error(
+    tidycomp:::.standardize_paired_categorical(data, "outcome", "group", "id"),
+    "exactly 2 levels"
+  )
+})


### PR DESCRIPTION
## Summary
- support binary outcomes with contingency-table diagnostics
- add engines for Fisher's exact, chi-squared (Yates and nxn), and McNemar tests
- extend engine selection and unit tests for new categorical analyses

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68a31801298483258efae8fa0a92a1a8