### PR TITLE
Add controllable correction for McNemar odds ratios

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 * Fixing wrong parsing of `conf_level`◔ to `effecsize` package functions. `conf_level` passes now to `ci`
 * Fixed failing tests and note about 'tails' not being imported or specified.
 * Added effect size support for categorical comparison engines (phi, Cramer's V, and odds ratio).
+* `set_effects()` gains a `correction` argument for controlling the
+  Haldane-Anscombe adjustment in McNemar odds ratios; `effects()` now
+  warns when the correction is applied or skipped.
 
 # tidycomp 0.3.0
 

--- a/man/effects.Rd
+++ b/man/effects.Rd
@@ -8,7 +8,8 @@ effects(
   x,
   type = c("auto", "ges", "pes", "eta2", "omega2", "epsilon2", "d", "g", "rank_biserial",
     "kendalls_w", "r2", "phi", "cramers_v", "oddsratio"),
-  conf_level = 0.95
+  conf_level = 0.95,
+  correction = TRUE
 )
 }
 \arguments{
@@ -23,6 +24,10 @@ an engine-/class-based default. Supported values: \code{"ges"}, \code{"pes"},
 
 \item{conf_level}{Confidence level (e.g., \code{0.90}); \code{NULL} for none. Defaults to
 \code{0.95}.}
+
+\item{correction}{Logical; apply a continuity correction when computing odds
+ratios for McNemar tests with zero discordant cells. Defaults to
+\code{TRUE}.}
 }
 \value{
 If \code{x} is a spec, the updated spec with \code{$effects};

--- a/man/set_effects.Rd
+++ b/man/set_effects.Rd
@@ -4,7 +4,8 @@
 \alias{set_effects}
 \title{Set effect size options}
 \usage{
-set_effects(x, type = "auto", conf_level = 0.95, compute = FALSE)
+set_effects(x, type = "auto", conf_level = 0.95, correction = TRUE,
+  compute = FALSE)
 }
 \arguments{
 \item{x}{A model specification object created with \code{\link{comp_spec}()}.}
@@ -18,6 +19,10 @@ Supported values include: \code{"ges"}, \code{"pes"}, \code{"eta2"},
 
 \item{conf_level}{Confidence interval level (e.g., 0.90). Use \code{NULL}
 to skip confidence intervals. Defaults to 0.95.}
+
+\item{correction}{Logical; apply a continuity correction when computing odds
+ratios for McNemar tests with zero discordant cells. Defaults to
+\code{TRUE}.}
 
 \item{compute}{Logical; if \code{TRUE}, \code{\link{test}()} will compute
 effect sizes automatically (by calling \code{effects()}) after the test.


### PR DESCRIPTION
## Summary
- allow `set_effects()`/`effects()` to toggle continuity correction for McNemar odds ratios
- warn users when Haldane–Anscombe correction is applied or skipped
- cover new behavior with tests and documentation

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68a47dc5dc188325868729dbfb9c3667