### PR TITLE
Warn on zero cells in categorical diagnostics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * `set_effects()` gains a `correction` argument for controlling the
   Haldane-Anscombe adjustment in McNemar odds ratios; `effects()` now
   warns when the correction is applied or skipped.
+* `diagnose()` warns about zero cells in categorical comparisons and suggests
+  inspecting `diagnostics$table` for details.
 
 # tidycomp 0.3.0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -271,7 +271,12 @@
   dims <- dim(tbl)
   is_2x2 <- all(dims == 2)
   any_lt5 <- any(tbl < 5)
+  any_zero <- any(tbl == 0)
   notes <- character()
+  if (any_zero) {
+    notes <- c(notes, "Zero cell detected; inspect diagnostics$table for details.")
+    cli::cli_warn("Zero cell detected in contingency table.")
+  }
   engine <- if (is_2x2) {
     if (any_lt5) {
       notes <- c(notes, "Cell count < 5 detected; using Fisher's exact test.")
@@ -302,12 +307,16 @@
   wide <- .standardize_paired_categorical(data, outcome, group, id)
   tbl <- table(wide[[1]], wide[[2]])
   discordant <- tbl[1, 2] + tbl[2, 1]
+  notes <- character()
   if (discordant < 25) {
-    notes <- "Discordant pairs < 25; using exact McNemar test."
+    notes <- c(notes, "Discordant pairs < 25; using exact McNemar test.")
     engine <- "mcnemar_exact"
   } else {
-    notes <- character()
     engine <- "mcnemar_chi2"
+  }
+  if (any(tbl == 0)) {
+    notes <- c(notes, "Zero cell detected; inspect diagnostics$table for details.")
+    cli::cli_warn("Zero cell detected in contingency table.")
   }
   list(table = tbl, expected = NULL, engine = engine, notes = notes)
 }

--- a/tests/testthat/test-diagnose.R
+++ b/tests/testthat/test-diagnose.R
@@ -31,6 +31,33 @@ test_that("diagnose reports contingency info for binary outcomes", {
   expect_equal(spec$diagnostics$engine, "fisher_exact")
 })
 
+test_that("diagnose warns about zero cells in unpaired contingency tables", {
+  df <- tibble::tibble(
+    outcome = factor(c("yes", "yes", "no", "no")),
+    group = factor(c("A", "A", "B", "B"))
+  )
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group) |>
+    set_design("independent") |>
+    set_outcome_type("binary")
+  expect_warning(spec <- diagnose(spec), "Zero cell detected")
+  expect_true(any(grepl("Zero cell", spec$diagnostics$notes)))
+})
+
+test_that("diagnose warns about zero cells in paired contingency tables", {
+  df <- tibble::tibble(
+    id = c(1, 1, 2, 2),
+    group = factor(c("A", "B", "A", "B")),
+    outcome = factor(c("yes", "yes", "yes", "no"))
+  )
+  spec <- comp_spec(df) |>
+    set_roles(outcome = outcome, group = group, id = id) |>
+    set_design("paired") |>
+    set_outcome_type("binary")
+  expect_warning(spec <- diagnose(spec), "Zero cell detected")
+  expect_true(any(grepl("Zero cell", spec$diagnostics$notes)))
+})
+
 test_that("diagnose errors when outcome is not numeric", {
   # Create a spec with non-numeric outcome
   df <- tibble::tibble(


### PR DESCRIPTION
## Summary
- Warn when contingency tables contain zero cells during diagnosis
- Suggest inspecting `diagnostics$table` for zero-cell details
- Test coverage for zero-cell warnings in paired and unpaired cases

## Testing
- `R -q -e "devtools::test()"` *(fails: Cannot have empty rows/columns in contingency tables)*

------
https://chatgpt.com/codex/tasks/task_e_68a49022e25c8325aba0ab4298b6ede7