### PR TITLE
Revise post hoc defaults and add CI support

### DIFF
--- a/R/post_hoc.R
+++ b/R/post_hoc.R
@@ -6,8 +6,9 @@
 #' @param x A model specification created with [comp_spec()].
 #' @param method Post-hoc method to use. Use "auto" to allow
 #'   [post_hoc()] to choose a sensible default based on the engine and data.
-#'   Possible values include "tukey", "bonferroni", "pairwise.wilcox",
-#'   "pairwise.prop", "games_howell", "dunn", and "regwq".
+#'   Possible values include "tukey", "bonferroni", "holm",
+#'   "pairwise_wilcox_test", "pairwise_prop_test", "games_howell",
+#'   and "dunn".
 #' @param alpha Significance level used to gate computation. If the
 #'   omnibus p-value is greater than or equal to `alpha`, post-hoc tests are
 #'   skipped unless `force` is `TRUE`.
@@ -15,6 +16,7 @@
 #'   omnibus test is not significant.
 #' @param compute Logical; if `TRUE`, [test()] will compute post-hoc
 #'   contrasts automatically after fitting the main test.
+#' @param conf_level Confidence level for intervals (default 0.95).
 #'
 #' @return The updated model specification.
 #' @export
@@ -23,11 +25,18 @@ set_post_hoc <- function(
   method = "auto",
   alpha = 0.05,
   force = FALSE,
-  compute = FALSE
+  compute = FALSE,
+  conf_level = 0.95
 ) {
   x$post_hoc_args <- utils::modifyList(
     x$post_hoc_args %||% list(),
-    list(method = method, alpha = alpha, force = force, compute = compute)
+    list(
+      method = method,
+      alpha = alpha,
+      force = force,
+      compute = compute,
+      conf_level = conf_level
+    )
   )
   x
 }
@@ -48,11 +57,13 @@ set_post_hoc <- function(
 #'   default based on the engine and data.
 #' @param alpha Significance level used for gating (default 0.05).
 #' @param force Logical; compute even if omnibus test is not significant.
+#' @param conf_level Confidence interval level (default 0.95).
 #'
 #' @return If `x` is a spec, the updated spec with `$post_hoc`; otherwise a
 #'   tibble of pairwise contrasts.
 #' @export
-post_hoc <- function(x, method = "auto", alpha = 0.05, force = FALSE) {
+post_hoc <- function(x, method = "auto", alpha = 0.05, force = FALSE,
+                     conf_level = 0.95) {
   is_spec <- inherits(x, "comp_spec")
   if (!is_spec) {
     cli::cli_abort("`post_hoc()` currently works on a `comp_spec`.")
@@ -69,6 +80,11 @@ post_hoc <- function(x, method = "auto", alpha = 0.05, force = FALSE) {
   }
   alpha <- if (!missing(alpha)) alpha else (user$alpha %||% 0.05)
   force <- if (!missing(force)) force else (user$force %||% FALSE)
+  conf_level <- if (!missing(conf_level)) {
+    conf_level
+  } else {
+    user$conf_level %||% 0.95
+  }
 
   if (identical(method, "auto")) {
     method <- .default_post_hoc_method(
@@ -92,84 +108,80 @@ post_hoc <- function(x, method = "auto", alpha = 0.05, force = FALSE) {
 
   res <- switch(
     method,
-    tukey = .ph_tukey(data, roles$outcome, roles$group),
+    tukey = .ph_tukey(data, roles$outcome, roles$group, conf_level),
     bonferroni = .ph_pairwise_t(
       data,
       roles$outcome,
       roles$group,
       x$design,
-      "bonferroni"
+      "bonferroni",
+      conf_level
     ),
-    `pairwise.t.test` = .ph_pairwise_t(
+    holm = .ph_pairwise_t(
       data,
       roles$outcome,
       roles$group,
       x$design,
-      "bonferroni"
+      "holm",
+      conf_level
     ),
-    `pairwise.wilcox` = .ph_pairwise_wilcox(
+    pairwise_t_test = .ph_pairwise_t(
       data,
       roles$outcome,
       roles$group,
       x$design,
-      "holm"
+      "bonferroni",
+      conf_level
     ),
-    `pairwise.wilcox.test` = .ph_pairwise_wilcox(
+    pairwise_wilcox_test = .ph_pairwise_wilcox(
       data,
       roles$outcome,
       roles$group,
       x$design,
-      "holm"
+      "holm",
+      conf_level
     ),
-    `pairwise.prop` = .ph_pairwise_prop(
+    pairwise_prop_test = .ph_pairwise_prop(
       data,
       roles$outcome,
       roles$group,
-      "bonferroni"
-    ),
-    `pairwise.prop.test` = .ph_pairwise_prop(
-      data,
-      roles$outcome,
-      roles$group,
-      "bonferroni"
+      "bonferroni",
+      conf_level
     ),
     games_howell = .ph_games_howell(
       data,
       roles$outcome,
-      roles$group
+      roles$group,
+      conf_level
     ),
     dunn = .ph_dunn(
       data,
       roles$outcome,
       roles$group,
-      "holm"
-    ),
-    regwq = .ph_regwq(
-      data,
-      roles$outcome,
-      roles$group
+      "holm",
+      conf_level
     ),
     cli::cli_abort("Unknown post-hoc method `{method}`.")
   )
 
   x$post_hoc_args <- utils::modifyList(
     user,
-    list(method = method, alpha = alpha, force = force)
+    list(method = method, alpha = alpha, force = force, conf_level = conf_level)
   )
   x$post_hoc <- res
   x
 }
 
 # choose default method based on engine/outcome
-.default_post_hoc_method <- function(engine, design, outcome_type) {
+ .default_post_hoc_method <- function(engine, design, outcome_type) {
   if (outcome_type == "binary") {
-    return("pairwise.prop.test")
+    return("pairwise_prop_test")
   }
   if (engine == "kruskal_wallis") {
     if (requireNamespace("rstatix", quietly = TRUE)) {
       return("dunn")
     }
-    return("pairwise.wilcox.test")
+    return("pairwise_wilcox_test")
   }
   if (
     engine == "anova_oneway_welch" &&
@@ -177,65 +189,101 @@ post_hoc <- function(x, method = "auto", alpha = 0.05, force = FALSE) {
   ) {
     return("games_howell")
   }
-  "bonferroni"
+  "tukey"
 }
 
-# convert lower-triangular matrix to tibble
-.matrix_to_tibble <- function(mat, method) {
-  df <- as.data.frame(as.table(mat))
-  df <- df[!is.na(df$Freq), , drop = FALSE]
-  if (nrow(df) == 0) {
-    return(tibble::tibble())
-  }
-  tibble::tibble(
-    group1 = as.character(df$Var1),
-    group2 = as.character(df$Var2),
-    p.value = as.numeric(df$Freq),
-    method = method
-  )
-}
-
-.ph_pairwise_t <- function(data, outcome, group, design, p.adjust) {
-  g <- data[[group]]
+.ph_pairwise_t <- function(data, outcome, group, design, p.adjust, conf_level) {
+  g <- factor(data[[group]])
   o <- data[[outcome]]
-  fit <- stats::pairwise.t.test(
-    o,
-    g,
-    p.adjust.method = p.adjust,
-    paired = design == "paired"
-  )
-  .matrix_to_tibble(fit$p.value, "pairwise.t.test")
+  combs <- utils::combn(levels(g), 2, simplify = FALSE)
+  res <- purrr::map_dfr(combs, function(pair) {
+    x1 <- o[g == pair[1]]
+    x2 <- o[g == pair[2]]
+    tt <- stats::t.test(
+      x1,
+      x2,
+      paired = design == "paired",
+      conf.level = conf_level
+    )
+    est <- if (length(tt$estimate) == 2) {
+      unname(tt$estimate[1] - tt$estimate[2])
+    } else {
+      unname(tt$estimate)
+    }
+    tibble::tibble(
+      group1 = pair[1],
+      group2 = pair[2],
+      estimate = est,
+      conf.low = tt$conf.int[1],
+      conf.high = tt$conf.int[2],
+      p.value = tt$p.value
+    )
+  })
+  res$p.adj <- stats::p.adjust(res$p.value, method = p.adjust)
+  res$p.adj.method <- p.adjust
+  res$method <- "t.test"
+  res
 }
 
-.ph_pairwise_wilcox <- function(data, outcome, group, design, p.adjust) {
-  g <- data[[group]]
+.ph_pairwise_wilcox <- function(data, outcome, group, design, p.adjust, conf_level) {
+  g <- factor(data[[group]])
   o <- data[[outcome]]
-  fit <- stats::pairwise.wilcox.test(
-    o,
-    g,
-    p.adjust.method = p.adjust,
-    paired = design == "paired"
-  )
-  .matrix_to_tibble(fit$p.value, "pairwise.wilcox.test")
+  combs <- utils::combn(levels(g), 2, simplify = FALSE)
+  res <- purrr::map_dfr(combs, function(pair) {
+    x1 <- o[g == pair[1]]
+    x2 <- o[g == pair[2]]
+    wt <- stats::wilcox.test(
+      x1,
+      x2,
+      paired = design == "paired",
+      conf.int = TRUE,
+      conf.level = conf_level,
+      exact = FALSE
+    )
+    tibble::tibble(
+      group1 = pair[1],
+      group2 = pair[2],
+      estimate = unname(wt$estimate %||% NA_real_),
+      conf.low = wt$conf.int[1],
+      conf.high = wt$conf.int[2],
+      p.value = wt$p.value
+    )
+  })
+  res$p.adj <- stats::p.adjust(res$p.value, method = p.adjust)
+  res$p.adj.method <- p.adjust
+  res$method <- "wilcox.test"
+  res
 }
 
-.ph_pairwise_prop <- function(data, outcome, group, p.adjust) {
-  g <- data[[group]]
+.ph_pairwise_prop <- function(data, outcome, group, p.adjust, conf_level) {
+  g <- factor(data[[group]])
   o <- data[[outcome]]
-  tbl <- table(g, o)
-  if (ncol(tbl) < 2) {
-    tbl <- cbind(tbl, 0)
-  }
-  success <- tbl[, 2]
-  n <- rowSums(tbl)
-  fit <- stats::pairwise.prop.test(success, n, p.adjust.method = p.adjust)
-  .matrix_to_tibble(fit$p.value, "pairwise.prop.test")
+  combs <- utils::combn(levels(g), 2, simplify = FALSE)
+  res <- purrr::map_dfr(combs, function(pair) {
+    x1 <- sum(o[g == pair[1]] == levels(o)[2])
+    n1 <- sum(g == pair[1])
+    x2 <- sum(o[g == pair[2]] == levels(o)[2])
+    n2 <- sum(g == pair[2])
+    pt <- stats::prop.test(c(x1, x2), c(n1, n2), conf.level = conf_level)
+    tibble::tibble(
+      group1 = pair[1],
+      group2 = pair[2],
+      estimate = unname(pt$estimate[1] - pt$estimate[2]),
+      conf.low = pt$conf.int[1],
+      conf.high = pt$conf.int[2],
+      p.value = pt$p.value
+    )
+  })
+  res$p.adj <- stats::p.adjust(res$p.value, method = p.adjust)
+  res$p.adj.method <- p.adjust
+  res$method <- "prop.test"
+  res
 }
 
-.ph_tukey <- function(data, outcome, group) {
+.ph_tukey <- function(data, outcome, group, conf_level) {
   f <- stats::as.formula(paste(outcome, "~", group))
   fit <- stats::aov(f, data = data)
-  ph <- stats::TukeyHSD(fit)
+  ph <- stats::TukeyHSD(fit, conf.level = conf_level)
   df <- tibble::as_tibble(ph[[1]], rownames = "comparison")
   comps <- tidyr::separate(
     df,
@@ -243,29 +291,47 @@ post_hoc <- function(x, method = "auto", alpha = 0.05, force = FALSE) {
     into = c("group1", "group2"),
     sep = "-"
   )
-  tibble::tibble(
+  tuk <- tibble::tibble(
     group1 = comps$group1,
     group2 = comps$group2,
-    p.value = df$`p adj`,
-    method = "TukeyHSD"
+    estimate = df$diff,
+    conf.low = df$lwr,
+    conf.high = df$upr,
+    p.adj = df$`p adj`
   )
+  g <- factor(data[[group]])
+  o <- data[[outcome]]
+  combs <- utils::combn(levels(g), 2, simplify = FALSE)
+  raw <- purrr::map_dfr(combs, function(pair) {
+    tt <- stats::t.test(o[g == pair[1]], o[g == pair[2]], conf.level = conf_level)
+    tibble::tibble(group1 = pair[1], group2 = pair[2], p.value = tt$p.value)
+  })
+  res <- dplyr::left_join(tuk, raw, by = c("group1", "group2"))
+  res$p.adj.method <- "tukey"
+  res$method <- "TukeyHSD"
+  res
 }
 
-.ph_games_howell <- function(data, outcome, group) {
+.ph_games_howell <- function(data, outcome, group, conf_level) {
   if (!requireNamespace("rstatix", quietly = TRUE)) {
-    cli::cli_abort("Package 'rstatix' is required for games_howell_test().")
+    cli::cli_abort("Package 'rstatix' is required for games_howell().")
   }
   f <- stats::as.formula(paste(outcome, "~", group))
-  res <- rstatix::games_howell_test(data, f)
+  res <- rstatix::games_howell_test(data, f, conf.level = conf_level)
   tibble::tibble(
     group1 = res$group1,
     group2 = res$group2,
-    p.value = res$p.adj,
+    estimate = res$estimate %||% res$mean.difference %||% NA_real_,
+    conf.low = res$conf.low,
+    conf.high = res$conf.high,
+    p.value = res$p,
+    p.adj = res$p.adj,
+    p.adj.method = "games_howell",
     method = "games_howell_test"
   )
 }
 
-.ph_dunn <- function(data, outcome, group, p.adjust) {
+.ph_dunn <- function(data, outcome, group, p.adjust, conf_level) {
   if (!requireNamespace("rstatix", quietly = TRUE)) {
     cli::cli_abort("Package 'rstatix' is required for dunn_test().")
   }
@@ -274,22 +340,12 @@ post_hoc <- function(x, method = "auto", alpha = 0.05, force = FALSE) {
   tibble::tibble(
     group1 = res$group1,
     group2 = res$group2,
-    p.value = res$p.adj,
+    estimate = NA_real_,
+    conf.low = NA_real_,
+    conf.high = NA_real_,
+    p.value = res$p,
+    p.adj = res$p.adj,
+    p.adj.method = p.adjust,
     method = "dunn_test"
   )
-}
-
-.ph_regwq <- function(data, outcome, group) {
-  if (!requireNamespace("mutoss", quietly = TRUE)) {
-    cli::cli_abort("Package 'mutoss' is required for regwq().")
-  }
-  g <- data[[group]]
-  o <- data[[outcome]]
-  fit <- mutoss::regwq(
-    o ~ g,
-    data = data,
-    alpha = 0.05,
-  )
-  mat <- fit$p.value
-  .matrix_to_tibble(mat, "regwq")
 }

--- a/man/post_hoc.Rd
+++ b/man/post_hoc.Rd
@@ -4,7 +4,7 @@
 \alias{post_hoc}
 \title{Compute pairwise post-hoc comparisons}
 \usage{
-post_hoc(x, method = "auto", alpha = 0.05, force = FALSE)
+post_hoc(x, method = "auto", alpha = 0.05, force = FALSE, conf_level = 0.95)
 }
 \arguments{
 \item{x}{A \code{comp_spec} that has been fit with \code{\link[=test]{test()}}. If not yet fit,
@@ -16,6 +16,8 @@ default based on the engine and data.}
 \item{alpha}{Significance level used for gating (default 0.05).}
 
 \item{force}{Logical; compute even if omnibus test is not significant.}
+
+\item{conf_level}{Confidence interval level (default 0.95).}
 }
 \value{
 If \code{x} is a spec, the updated spec with \verb{$post_hoc}; otherwise a

--- a/man/set_post_hoc.Rd
+++ b/man/set_post_hoc.Rd
@@ -4,15 +4,22 @@
 \alias{set_post_hoc}
 \title{Set post-hoc options}
 \usage{
-set_post_hoc(x, method = "auto", alpha = 0.05, force = FALSE, compute = FALSE)
+set_post_hoc(
+  x,
+  method = "auto",
+  alpha = 0.05,
+  force = FALSE,
+  compute = FALSE,
+  conf_level = 0.95
+)
 }
 \arguments{
 \item{x}{A model specification created with \code{\link[=comp_spec]{comp_spec()}}.}
 
 \item{method}{Post-hoc method to use. Use "auto" to allow
 \code{\link[=post_hoc]{post_hoc()}} to choose a sensible default based on the engine and data.
-Possible values include "tukey", "bonferroni", "pairwise.wilcox",
-"pairwise.prop", "games_howell", "dunn", and "regwq".}
+Possible values include "tukey", "bonferroni", "holm",
+"pairwise_wilcox_test", "pairwise_prop_test", "games_howell", and "dunn".}
 
 \item{alpha}{Significance level used to gate computation. If the
 omnibus p-value is greater than or equal to \code{alpha}, post-hoc tests are
@@ -23,6 +30,8 @@ omnibus test is not significant.}
 
 \item{compute}{Logical; if \code{TRUE}, \code{\link[=test]{test()}} will compute post-hoc
 contrasts automatically after fitting the main test.}
+
+\item{conf_level}{Confidence level for intervals (default 0.95).}
 }
 \value{
 The updated model specification.

--- a/tests/testthat/test-post-hoc.R
+++ b/tests/testthat/test-post-hoc.R
@@ -6,7 +6,7 @@ df <- tibble::tibble(
   group = factor(rep(c("A","B","C"), each = 4))
 )
 
-test_that("post_hoc defaults to pairwise.t.test", {
+test_that("post_hoc defaults to TukeyHSD", {
   spec <- comp_spec(df) |>
     set_roles(outcome = outcome, group = group) |>
     set_design("independent") |>
@@ -16,20 +16,20 @@ test_that("post_hoc defaults to pairwise.t.test", {
     post_hoc()
 
   expect_s3_class(spec$post_hoc, "tbl_df")
-  expect_equal(unique(spec$post_hoc$method), "pairwise.t.test")
+  expect_equal(unique(spec$post_hoc$method), "TukeyHSD")
 })
 
- test_that("set_post_hoc overrides method", {
+test_that("set_post_hoc overrides method", {
   spec <- comp_spec(df) |>
     set_roles(outcome = outcome, group = group) |>
     set_design("independent") |>
     set_outcome_type("numeric") |>
     set_engine("anova_oneway_equal") |>
-    set_post_hoc(method = "tukey") |>
+    set_post_hoc(method = "bonferroni") |>
     test() |>
     post_hoc()
 
-  expect_true(any(grepl("Tukey", spec$post_hoc$method)))
+  expect_equal(unique(spec$post_hoc$p.adj.method), "bonferroni")
 })
 
 test_that("post_hoc skips when omnibus not significant", {
@@ -49,7 +49,7 @@ test_that("post_hoc skips when omnibus not significant", {
   expect_true(isTRUE(attr(spec$post_hoc, "skipped")))
 })
 
-test_that("kruskal-wallis uses pairwise.wilcox.test by default", {
+test_that("kruskal-wallis uses pairwise_wilcox_test by default", {
   spec <- comp_spec(df) |>
     set_roles(outcome = outcome, group = group) |>
     set_design("independent") |>
@@ -58,7 +58,7 @@ test_that("kruskal-wallis uses pairwise.wilcox.test by default", {
     test() |>
     post_hoc()
 
-  expect_equal(unique(spec$post_hoc$method), "pairwise.wilcox.test")
+  expect_equal(unique(spec$post_hoc$method), "wilcox.test")
 })
 
 df_bin <- tibble::tibble(
@@ -66,7 +66,7 @@ df_bin <- tibble::tibble(
   group = factor(rep(c("A","B","C"), each = 4))
 )
 
-test_that("binary outcomes use pairwise.prop.test", {
+test_that("binary outcomes use pairwise_prop_test", {
   spec <- comp_spec(df_bin) |>
     set_roles(outcome = outcome, group = group) |>
     set_design("independent") |>
@@ -75,5 +75,5 @@ test_that("binary outcomes use pairwise.prop.test", {
     test() |>
     post_hoc()
 
-  expect_equal(unique(spec$post_hoc$method), "pairwise.prop.test")
+  expect_equal(unique(spec$post_hoc$method), "prop.test")
 })


### PR DESCRIPTION
## Summary
- default to Tukey HSD for post-hoc comparisons and rename options with underscores
- add p-values, adjusted p-values, and confidence intervals to post-hoc outputs
- drop REGWQ support and update tests and docs for new API

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get install -y r-base-core` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a5abda1d188325940ded5b11375391